### PR TITLE
Include file name in response, and support "Accept" header that contain charset property

### DIFF
--- a/src/core/api.js
+++ b/src/core/api.js
@@ -67,7 +67,7 @@ export function runAPI(express, app, gitCommit, gitBranch, __dirname) {
 
     app.use('/api/json', express.json({
         verify: (req, res, buf) => {
-            let acceptCon = String(req.header('Accept')) === "application/json";
+            let acceptCon = String(req.header('Accept')) === "application/json" || String(req.header('Accept')) === "application/json; charset=utf-8";
             if (acceptCon) {
                 if (buf.length > 720) throw new Error();
                 JSON.parse(buf);
@@ -80,7 +80,7 @@ export function runAPI(express, app, gitCommit, gitBranch, __dirname) {
     // handle express.json errors properly (https://github.com/expressjs/express/issues/4065)
     app.use('/api/json', (err, req, res, next) => {
         let errorText = "invalid json body";
-        let acceptCon = String(req.header('Accept')) !== "application/json";
+        let acceptCon = String(req.header('Accept')) !== "application/json" && String(req.header('Accept')) !== "application/json; charset=utf-8";
 
         if (err || acceptCon) {
             if (acceptCon) errorText = "invalid accept header";
@@ -98,7 +98,7 @@ export function runAPI(express, app, gitCommit, gitBranch, __dirname) {
             let lang = languageCode(req);
             let j = apiJSON(0, { t: "bad request" });
             try {
-                let contentCon = String(req.header('Content-Type')) === "application/json";
+                let contentCon = String(req.header('Accept')) === "application/json" || String(req.header('Accept')) === "application/json; charset=utf-8";
                 let request = req.body;
                 if (contentCon && request.url) {
                     request.dubLang = request.dubLang ? lang : false;

--- a/src/modules/sub/utils.js
+++ b/src/modules/sub/utils.js
@@ -15,13 +15,22 @@ const forbiddenCharsString = ['}', '{', '%', '>', '<', '^', ';', '`', '$', '"', 
 
 export function apiJSON(type, obj) {
     try {
+        try {
+            var filename = obj.filename;
+            if (obj.isAudioOnly == true && typeof filename == 'string' && !filename.endsWith(".mp3") && !filename.endsWith(".ogg") && !filename.endsWith(".wav") && !filename.endsWith(".opus")) {
+                obj.filename = filename + '.mp3';
+            }
+        } catch (e) {
+            return { status: 500, body: { status: "error", text: "Internal Server Error", critical: true } };
+        }
+
         switch (type) {
             case 0:
                 return { status: 400, body: { status: "error", text: obj.t } };
             case 1:
-                return { status: 200, body: { status: "redirect", url: obj.u } };
+                return { status: 200, body: { status: "redirect", url: obj.u, filename: obj.filename } };
             case 2:
-                return { status: 200, body: { status: "stream", url: createStream(obj) } };
+                return { status: 200, body: { status: "stream", url: createStream(obj), filename: obj.filename } };
             case 3:
                 return { status: 200, body: { status: "success", text: obj.t } };
             case 4:


### PR DESCRIPTION
This PR has been made to allow clients to use the API with an `Accept` header defined to `application/json; charset=utf-8`, which is especially useful for Flutter apps, as they automatically set it instead of the regular `application/json`.

Additionally, when requesting a download, the API will now return the name of the file. This enhancement aims to improve the developer experience when programmatically accessing Cobalt.