### PR TITLE
pinterest: implement image and gifs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ this list is not final and keeps expanding over time. if support for a service y
 | twitter/x  | lets you pick what to save from multi-media posts. may not be 100% reliable due to current management.               |
 | vimeo      | audio downloads are only available for dash.                                                                         |
 | youtube    | supports videos, music, and shorts. 8K, 4K, HDR, VR, and high FPS videos. rich metadata & dubs. h264/av1/vp9 codecs. |
+| pinterest  | supports gifs, videos, and images                                                                                    |
 
 ## cobalt api
 cobalt has an open api that you can use in your projects *for free~*. it's easy and straightforward to use, [check out the docs](/docs/api.md) to learn how to use it. 

--- a/README.md
+++ b/README.md
@@ -42,14 +42,13 @@ this list is not final and keeps expanding over time. if support for a service y
 | service    | notes or features                                                                                                    |
 | :--------  | :-----                                                                                                               |
 | instagram  | supports photos, videos, and stories. lets you pick what to save from multi-media posts.                             |
-| pinterest  | supports videos and stories.                                                                                         |
+| pinterest  | supports photos, gifs, videos and stories.                                                                           |
 | reddit     | supports gifs and videos.                                                                                            |
 | soundcloud | supports private links.                                                                                              |
 | tiktok     | supports videos with or without watermark, images from slideshow without watermark, and full (original) audios.      |
 | twitter/x  | lets you pick what to save from multi-media posts. may not be 100% reliable due to current management.               |
 | vimeo      | audio downloads are only available for dash.                                                                         |
 | youtube    | supports videos, music, and shorts. 8K, 4K, HDR, VR, and high FPS videos. rich metadata & dubs. h264/av1/vp9 codecs. |
-| pinterest  | supports gifs, videos, and images                                                                                    |
 
 ## cobalt api
 cobalt has an open api that you can use in your projects *for free~*. it's easy and straightforward to use, [check out the docs](/docs/api.md) to learn how to use it. 

--- a/src/modules/processing/services/pinterest.js
+++ b/src/modules/processing/services/pinterest.js
@@ -1,6 +1,7 @@
 import { genericUserAgent } from "../../config.js";
 
-const linkRegex = /"url":"(https:\/\/v1.pinimg.com\/videos\/.*?)"/g;
+const videoRegex = /"url":"(https:\/\/v1.pinimg.com\/videos\/.*?)"/g;
+const imageRegex = /src="(https:\/\/i\.pinimg\.com\/.*\.(jpg|gif))"/g;
 
 export default async function(o) {
     let id = o.id;
@@ -19,15 +20,24 @@ export default async function(o) {
 
     if (!html) return { error: 'ErrorCouldntFetch' };
 
-    let videoLink = [...html.matchAll(linkRegex)]
+    let videoLink = [...html.matchAll(videoRegex)]
                     .map(([, link]) => link)
                     .filter(a => a.endsWith('.mp4') && a.includes('720p'))[0];
 
-    if (!videoLink) return { error: 'ErrorEmptyDownload' };
-
-    return {
+    if (videoLink) return {
         urls: videoLink,
         filename: `pinterest_${o.id}.mp4`,
         audioFilename: `pinterest_${o.id}_audio`
     }
+
+    let imageLink = [...html.matchAll(imageRegex)]
+                    .map(([, link]) => link)
+                    .filter(a => a.endsWith('.jpg') || a.endsWith('.gif'))[0];
+                    
+    if (imageLink) return {
+        urls: imageLink,
+        isPhoto: true
+    }
+
+    return { error: 'ErrorEmptyDownload' };
 }

--- a/src/modules/processing/services/pinterest.js
+++ b/src/modules/processing/services/pinterest.js
@@ -22,7 +22,7 @@ export default async function(o) {
 
     let videoLink = [...html.matchAll(videoRegex)]
                     .map(([, link]) => link)
-                    .filter(a => a.endsWith('.mp4') && a.includes('720p'))[0];
+                    .find(a => a.endsWith('.mp4') && a.includes('720p'));
 
     if (videoLink) return {
         urls: videoLink,
@@ -32,7 +32,7 @@ export default async function(o) {
 
     let imageLink = [...html.matchAll(imageRegex)]
                     .map(([, link]) => link)
-                    .filter(a => a.endsWith('.jpg') || a.endsWith('.gif'))[0];
+                    .find(a => a.endsWith('.jpg') || a.endsWith('.gif'));
                     
     if (imageLink) return {
         urls: imageLink,

--- a/src/modules/processing/servicesConfig.json
+++ b/src/modules/processing/servicesConfig.json
@@ -93,7 +93,7 @@
             "enabled": true
         },
         "pinterest": {
-            "alias": "pinterest videos & stories",
+            "alias": "pinterest (all media)",
             "patterns": ["pin/:id", "pin/:id/:garbage", "url_shortener/:shortLink"],
             "enabled": true
         },

--- a/src/test/tests.json
+++ b/src/test/tests.json
@@ -976,6 +976,38 @@
             "code": 200,
             "status": "redirect"
         }
+    }, {
+        "name": "regular picture",
+        "url": "https://www.pinterest.com/pin/412994228343400946/",
+        "params": {},
+        "expected": {
+            "code": 200,
+            "status": "redirect"
+        }
+    }, {
+        "name": "regular picture (.ca TLD)",
+        "url": "https://www.pinterest.ca/pin/412994228343400946/",
+        "params": {},
+        "expected": {
+            "code": 200,
+            "status": "redirect"
+        }
+    }, {
+        "name": "regular gif",
+        "url": "https://www.pinterest.com/pin/814447913881127862/",
+        "params": {},
+        "expected": {
+            "code": 200,
+            "status": "redirect"
+        }
+    }, {
+        "name": "regular gif (.ca TLD)",
+        "url": "https://www.pinterest.ca/pin/814447913881127862/",
+        "params": {},
+        "expected": {
+            "code": 200,
+            "status": "redirect"
+        }
     }],
     "streamable": [{
         "name": "regular video",


### PR DESCRIPTION
Pretty simple pull request, implemented support for pictures and gifs for Pinterest as suggested in #439. 
Not sure how necessary pictures are, but gifs will be very useful as user needs to register or open devtools to download them :3

There is no support for "slides", if they still exist, which I'm not sure since I haven't used Pinterest for a long time, or they just don't show up for unauthorized users. (I tried to find them, and failed :D). 