### PR TITLE
web: stop password managers from autofilling data into url area

### DIFF
--- a/src/modules/pageRender/page.js
+++ b/src/modules/pageRender/page.js
@@ -594,7 +594,7 @@ export default function(obj) {
                 <div id="download-area">
                     <div id="top">
                         <div id="link-icon">${linkSVG}</div>
-                        <input id="url-input-area" class="mono" type="text" autocomplete="off" spellcheck="false" maxlength="256" autocapitalize="off" placeholder="${t('LinkInput')}" aria-label="${t('AccessibilityInputArea')}" oninput="button()">
+                        <input id="url-input-area" class="mono" type="text" autocomplete="off" data-form-type="other" spellcheck="false" maxlength="256" autocapitalize="off" placeholder="${t('LinkInput')}" aria-label="${t('AccessibilityInputArea')}" oninput="button()">
                         <button id="url-clear" onclick="clearInput()" style="display:none;">x</button>
                         <input id="download-button" class="mono dontRead" onclick="download(document.getElementById('url-input-area').value)" type="submit" value="" disabled aria-label="${t('AccessibilityDownloadButton')}">
                     </div>


### PR DESCRIPTION
This adds the "data-form-type" attribute "other" which stops Dashlane from auto filling. 

https://dashlane.github.io/SAWF/#data-form-type-attribute-other-value