### PR TITLE
automatically focus the url input field on page load

### DIFF
--- a/src/front/cobalt.js
+++ b/src/front/cobalt.js
@@ -666,6 +666,10 @@ window.onload = () => {
     }
     window.history.replaceState(null, '', window.location.pathname);
 
+    if (!isMobile) {
+        eid("url-input-area").focus();
+    }
+
     // fix for animations not working in Safari
     if (isIOS) {
         document.addEventListener('touchstart', () => {}, true);


### PR DESCRIPTION
Cobalt now auto-focuses the url input field on page load (on desktop). This allows for a more seamless experience, as you now only need to press CTRL-V instead of selecting the input field with your mouse.

On mobile devices, however, this behaviour could be jarring; having the keyboard pop up on load can be confusing and cover up the website's contents. This has been prevented.

resolves #546