### PR TITLE
rutube: video quality fallback bugfix

### DIFF
--- a/src/modules/processing/services/rutube.js
+++ b/src/modules/processing/services/rutube.js
@@ -52,6 +52,12 @@ export default async function(obj) {
         bestQuality = m3u8.find((i) => (Number(quality) === i.resolution.height));
     }
 
+    if(bestQuality == null) {
+        bestQuality = m3u8.reduce((prev, curr) => {
+            return Math.abs(Number(curr.resolution.height) - Number(quality)) < Math.abs(Number(prev.resolution.height) - Number(quality)) ? curr : prev;
+        });    
+    }
+
     const fileMetadata = {
         title: cleanString(play.title.trim()),
         artist: cleanString(play.author.name.trim()),


### PR DESCRIPTION
fixes #562!

checks if the requested quality exists, and if not, uses the closest one.