### PR TITLE
feat: support external proxies

### DIFF
--- a/docs/run-an-instance.md
+++ b/docs/run-an-instance.md
@@ -56,6 +56,7 @@ sudo service nscd start
 | `API_LISTEN_ADDRESS`  | `0.0.0.0` | `127.0.0.1`             | changes address from which api server is accessible. **if you are using docker, you usually don't need to configure this.** |
 | `API_URL`             | ➖        | `https://api.cobalt.tools/` | changes url from which api server is accessible. <br> ***REQUIRED TO RUN THE API***. |
 | `API_NAME`            | `unknown` | `ams-1`                 | api server name that is shown in `/api/serverInfo`. |
+| `API_EXTERNAL_PROXY`  | ➖        | `http://user:password@127.0.0.1:8080`| url of the proxy that will be passed to [`ProxyAgent`](https://undici.nodejs.org/#/docs/api/ProxyAgent) and used for all external requests. HTTP(S) only. |
 | `CORS_WILDCARD`       | `1`       | `0`                     | toggles cross-origin resource sharing. <br> `0`: disabled. `1`: enabled. |
 | `CORS_URL`            | not used  | `https://cobalt.tools/` | cross-origin resource sharing url. api will be available only from this url if `CORS_WILDCARD` is set to `0`. |
 | `COOKIE_PATH`         | not used  | `/cookies.json`         | path for cookie file relative to main folder. |

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -1,5 +1,6 @@
 import cors from "cors";
 import rateLimit from "express-rate-limit";
+import { setGlobalDispatcher, ProxyAgent } from "undici";
 
 import { env, version } from "../modules/config.js";
 
@@ -218,6 +219,10 @@ export function runAPI(express, app, gitCommit, gitBranch, __dirname) {
 
     randomizeCiphers();
     setInterval(randomizeCiphers, 1000 * 60 * 30); // shuffle ciphers every 30 minutes
+
+    if (env.externalProxy) {
+        setGlobalDispatcher(new ProxyAgent(env.externalProxy))
+    }
 
     app.listen(env.apiPort, env.listenAddress, () => {
         console.log(`\n` +

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -221,6 +221,10 @@ export function runAPI(express, app, gitCommit, gitBranch, __dirname) {
     setInterval(randomizeCiphers, 1000 * 60 * 30); // shuffle ciphers every 30 minutes
 
     if (env.externalProxy) {
+        if (env.freebindCIDR) {
+            throw new Error('Freebind is not available when external proxy is enabled')
+        }
+
         setGlobalDispatcher(new ProxyAgent(env.externalProxy))
     }
 

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -48,7 +48,9 @@ const
 
         processingPriority: process.platform !== 'win32'
                                 && process.env.PROCESSING_PRIORITY
-                                && parseInt(process.env.PROCESSING_PRIORITY)
+                                && parseInt(process.env.PROCESSING_PRIORITY),
+
+        externalProxy: process.env.API_EXTERNAL_PROXY,
     }
 
 export const


### PR DESCRIPTION
added support for `API_EXTERNAL_PROXY` env variable that sets up a global undici dispatcher

definitely not the best way to do this (i really dislike relying on globals), but did it like this anyway because:
 - there isn't a single common wrapper over `fetch()` where i could provide a `dispatcher`
 - passing it manually everywhere is very tedious and error-prone (especially considering there aren't any types)
 - since api is supposed to run in a separate isolated process it probably won't affect what it isn't supposed to

one thing i worry about is the youtube handler which mentions reading `dispatcher` from `streamInfo`, but i couldn't find a place where it is being passed there 🧐