### PR TITLE
feat: adds audio quality as an api param

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -25,6 +25,7 @@ Content-Type: application/json
 | `vCodec`          | `string`  | `h264 / av1 / vp9`                 | `h264`    | applies only to youtube downloads. `h264` is recommended for phones.            |
 | `vQuality`        | `string`  | `144 / ... / 2160 / max`           | `720`     | `720` quality is recommended for phones.                                        |
 | `aFormat`         | `string`  | `best / mp3 / ogg / wav / opus`    | `mp3`     |                                                                                 |
+| `aQuality`         | `string`  | `320 / 192 / 128 / 64`    | `320`     | adjusts the bitrate of the converted output file when downloading audio|
 | `filenamePattern` | `string`  | `classic / pretty / basic / nerdy` | `classic` | changes the way files are named. previews can be seen in the web app.           |
 | `isAudioOnly`     | `boolean` | `true / false`                     | `false`   |                                                                                 |
 | `isTTFullAudio`   | `boolean` | `true / false`                     | `false`   | enables download of original sound used in a tiktok video.                      |

--- a/src/config.json
+++ b/src/config.json
@@ -86,7 +86,7 @@
         "webm": ["-c:v", "copy", "-c:a", "copy"],
         "mp4": ["-c:v", "copy", "-c:a", "copy", "-movflags", "faststart+frag_keyframe+empty_moov"],
         "copy": ["-c:a", "copy"],
-        "audio": ["-ar", "48000", "-ac", "2", "-b:a", "320k"],
+        "audio": ["-ar", "48000", "-ac", "2"],
         "m4a": ["-movflags", "frag_keyframe+empty_moov"],
         "gif": ["-vf", "scale=-1:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse", "-loop", "0"]
     },

--- a/src/modules/processing/match.js
+++ b/src/modules/processing/match.js
@@ -216,7 +216,7 @@ export default async function(host, patternMatch, lang, obj) {
         }
 
         return matchActionDecider(
-            r, host, obj.aFormat, isAudioOnly,
+            r, host, obj.aQuality, obj.aFormat, isAudioOnly,
             lang, isAudioMuted, disableMetadata,
             obj.filenamePattern, obj.twitterGif,
             requestIP

--- a/src/modules/processing/matchActionDecider.js
+++ b/src/modules/processing/matchActionDecider.js
@@ -4,7 +4,7 @@ import loc from "../../localization/manager.js";
 import createFilename from "./createFilename.js";
 import { createStream } from "../stream/manage.js";
 
-export default function(r, host, userFormat, isAudioOnly, lang, isAudioMuted, disableMetadata, filenamePattern, toGif, requestIP) {
+export default function(r, host, audioBitrate, userFormat, isAudioOnly, lang, isAudioMuted, disableMetadata, filenamePattern, toGif, requestIP) {
     let action,
         responseType = "stream",
         defaultParams = {
@@ -31,6 +31,7 @@ export default function(r, host, userFormat, isAudioOnly, lang, isAudioMuted, di
         if (!r.filenameAttributes) defaultParams.filename = r.audioFilename;
         defaultParams.isAudioOnly = true;
         defaultParams.audioFormat = audioFormat;
+        defaultParams.audioQuality = audioBitrate;
     }
     if (isAudioMuted && !r.filenameAttributes) {
         defaultParams.filename = r.filename.replace('.', '_mute.')

--- a/src/modules/processing/request.js
+++ b/src/modules/processing/request.js
@@ -8,6 +8,7 @@ const apiVar = {
     allowed: {
         vCodec: ["h264", "av1", "vp9"],
         vQuality: ["max", "4320", "2160", "1440", "1080", "720", "480", "360", "240", "144"],
+        aQuality: ["320", "192", "128", "64"],
         aFormat: ["best", "mp3", "ogg", "wav", "opus"],
         filenamePattern: ["classic", "pretty", "basic", "nerdy"]
     },
@@ -107,6 +108,7 @@ export function normalizeRequest(request) {
             url: normalizeURL(decodeURIComponent(request.url)),
             vCodec: "h264",
             vQuality: "720",
+            aQuality: "320",
             aFormat: "mp3",
             filenamePattern: "classic",
             isAudioOnly: false,

--- a/src/modules/stream/manage.js
+++ b/src/modules/stream/manage.js
@@ -37,6 +37,7 @@ export function createStream(obj) {
             service: obj.service,
             filename: obj.filename,
             audioFormat: obj.audioFormat,
+            audioQuality: obj.audioQuality,
             isAudioOnly: !!obj.isAudioOnly,
             headers: obj.headers,
             copy: !!obj.copy,

--- a/src/modules/stream/types.js
+++ b/src/modules/stream/types.js
@@ -156,6 +156,11 @@ export function streamAudioOnly(streamInfo, res) {
             args = args.concat(ffmpegArgs[streamInfo.audioFormat])
         }
 
+        args.push(
+            '-b:a',
+            `${streamInfo.audioQuality}k`
+        );
+
         args.push('-f', streamInfo.audioFormat === "m4a" ? "ipod" : streamInfo.audioFormat, 'pipe:3');
 
         process = spawn(...getCommand(args), {


### PR DESCRIPTION
Added support for audio quality (bitrate) as an API param (optional). Send `aQuality` as an optional parameter to the API.

closes partially #251 