### PR TITLE
linkedin: add linkedin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ this list is not final and keeps expanding over time. if support for a service y
 | bilibili.com & bilibili.tv     | ✅            | ✅         | ✅         | ➖         | ➖              |
 | dailymotion                    | ✅            | ✅         | ✅         | ✅         | ✅              |
 | instagram posts & reels        | ✅            | ✅         | ✅         | ➖         | ➖              |
+| linkedin                       | ✅            | ✅         | ✅         | ❌         | ❌              |
 | loom                           | ✅            | ❌         | ✅         | ✅         | ➖              |
 | ok video                       | ✅            | ❌         | ✅         | ✅         | ✅              |
 | pinterest                      | ✅            | ✅         | ✅         | ➖         | ➖              |
@@ -45,6 +46,7 @@ this list is not final and keeps expanding over time. if support for a service y
 | service    | notes or features                                                                                                    |
 | :--------  | :-----                                                                                                               |
 | instagram  | supports reels, photos, and videos. lets you pick what to save from multi-media posts.                               |
+| linkedin   | supports post and feed links.                                                                                        |
 | pinterest  | supports photos, gifs, videos and stories.                                                                           |
 | reddit     | supports gifs and videos.                                                                                            |
 | rutube     | supports yappy & private links.                                                                                      |

--- a/src/modules/processing/match.js
+++ b/src/modules/processing/match.js
@@ -25,6 +25,7 @@ import twitch from "./services/twitch.js";
 import rutube from "./services/rutube.js";
 import dailymotion from "./services/dailymotion.js";
 import loom from "./services/loom.js";
+import linkedin from "./services/linkedin.js";
 
 let freebind;
 
@@ -191,6 +192,12 @@ export default async function(host, patternMatch, lang, obj) {
             case "loom":
                 r = await loom({
                     id: patternMatch.id
+                });
+                break;
+            case "linkedin":
+                r = await linkedin({
+                    postId: patternMatch.id,
+                    quality: obj.vQuality
                 });
                 break;
             default:

--- a/src/modules/processing/services/linkedin.js
+++ b/src/modules/processing/services/linkedin.js
@@ -1,0 +1,62 @@
+import { genericUserAgent } from "../../config.js";
+
+const qualityMatch = {
+    "mp4-640p-30fp-crf28": 640,
+    "mp4-720p-30fp-crf28": 720
+};
+
+export default async function (obj) {
+    const html = await fetch(
+        `https://www.linkedin.com/feed/update/urn:li:activity:${obj.postId}`,
+        { headers: { "user-agent": genericUserAgent } }
+    )
+        .then((res) => res.text())
+        .catch(() => {});
+
+    if (!html) {
+        return { error: "ErrorCouldntFetch" };
+    }
+
+    let data;
+    try {
+        const json = html
+            .split('data-sources="')[1]
+            .split('" data-poster-url="')[0]
+            .replaceAll("&quot;", '"')
+            .replaceAll("&amp;", "&");
+        data = JSON.parse(json);
+    } catch (error) {
+        return { error: "ErrorCouldntFetch" };
+    }
+
+    let fallbackUrl;
+    const quality = obj.quality === "max" || obj.quality >= 720 ? 720 : 640;
+    const filenameBase = `linkedin_${obj.postId}`;
+
+    for (const source of data) {
+        const videoQuality = qualityMatch[source.src.split("/")[6]];
+
+        if (videoQuality === quality) {
+            return {
+                urls: source.src,
+                filename: `${filenameBase}.mp4`,
+                audioFilename: `${filenameBase}_audio`
+            };
+            // will prioritize using known quality over unknown quality if no matching quality
+        } else if (!videoQuality && !fallbackUrl) {
+            fallbackUrl = source.src;
+        } else {
+            fallbackUrl = source.src;
+        }
+    }
+
+    if (fallbackUrl) {
+        return {
+            urls: fallbackUrl,
+            filename: `${filenameBase}.mp4`,
+            audioFilename: `${filenameBase}_audio`
+        };
+    }
+
+    return { error: "ErrorEmptyDownload" };
+}

--- a/src/modules/processing/servicesConfig.json
+++ b/src/modules/processing/servicesConfig.json
@@ -33,7 +33,6 @@
         "vk": {
             "alias": "vk video & clips",
             "patterns": ["video:userId_:videoId", "clip:userId_:videoId", "clips:duplicate?z=clip:userId_:videoId"],
-            "subdomains": ["m"],
             "enabled": true
         },
         "ok": {
@@ -117,6 +116,11 @@
         "loom": {
             "alias": "loom videos",
             "patterns": ["share/:id"],
+            "enabled": true
+        },
+        "linkedin": {
+            "alias": "linkedin videos",
+            "patterns": ["feed/update/urn\\:li\\:activity\\:(:id)"],
             "enabled": true
         }
     }

--- a/src/modules/processing/servicesPatternTesters.js
+++ b/src/modules/processing/servicesPatternTesters.js
@@ -9,6 +9,9 @@ export const testers = {
         patternMatch.postId?.length <= 12
         || (patternMatch.username?.length <= 30 && patternMatch.storyId?.length <= 24),
 
+    "linkedin": (patternMatch) =>
+        patternMatch.id?.length === 19,
+
     "loom": (patternMatch) =>
         patternMatch.id?.length <= 32,
 

--- a/src/modules/processing/url.js
+++ b/src/modules/processing/url.js
@@ -70,6 +70,12 @@ function aliasURL(url) {
                 url.hostname = 'instagram.com';
             }
             break;
+        case "linkedin":
+            if (parts[1] === "posts") {
+                const postId = parts.pop().split("-").at(-2)
+                url = new URL(`https://linkedin.com/feed/update/urn:li:activity:${postId}`)
+            }
+            break;
     }
 
     return url

--- a/src/util/tests.json
+++ b/src/util/tests.json
@@ -1160,5 +1160,42 @@
             "code": 200,
             "status": "stream"
         }
+    }],
+    "linkedin": [{
+        "name": "regular video (share link)",
+        "url": "https://www.linkedin.com/posts/jasonyoong_in-the-early-days-of-a-startup-sam-altman-activity-7211912701411827712-oR9m?utm_source=share",
+        "params": {},
+        "expected": {
+            "code": 200,
+            "status": "stream"
+        }
+    }, {
+        "name": "regular video (feed link)",
+        "url": "https://www.linkedin.com/feed/update/urn:li:activity:7211912701411827712/",
+        "params": {},
+        "expected": {
+            "code": 200,
+            "status": "stream"
+        }
+    }, {
+        "name": "regular video (isAudioMuted)",
+        "url": "https://www.linkedin.com/feed/update/urn:li:activity:7211912701411827712/",
+        "params": {
+            "isAudioMuted": true
+        },
+        "expected": {
+            "code": 200,
+            "status": "stream"
+        }
+    }, {
+        "name": "regular video (isAudioOnly)",
+        "url": "https://www.linkedin.com/feed/update/urn:li:activity:7211912701411827712/",
+        "params": {
+            "isAudioOnly": true
+        },
+        "expected": {
+            "code": 200,
+            "status": "stream"
+        }
     }]
 }


### PR DESCRIPTION
Adds LinkedIn support to cobalt.

Notes:
- Compatible with regular video, video only, and audio only.
- LinkedIn videos, for the most part, are only in 640p or 720p. There is also sometimes an unknown quality that is being used as a fallback if neither 640p or 720p exist.
- Works with both feed links and post links.