### PR TITLE
tests: fix broken twitter links

### DIFF
--- a/src/util/tests.json
+++ b/src/util/tests.json
@@ -1,7 +1,7 @@
 {
     "twitter": [{
         "name": "regular video",
-        "url": "https://twitter.com/TwitterSpaces/status/1526955853743546372?s=20",
+        "url": "https://twitter.com/XSpaces/status/1526955853743546372?s=20",
         "params": {
             "aFormat": "mp3",
             "isAudioOnly": false,
@@ -34,7 +34,7 @@
         }
     }, {
         "name": "mixed media (image + gif)",
-        "url": "https://twitter.com/Twitter/status/1580661436132757506?s=20",
+        "url": "https://twitter.com/sky_mj26/status/1807756010712428565",
         "params": {
             "aFormat": "mp3",
             "isAudioOnly": false,

--- a/src/util/tests.json
+++ b/src/util/tests.json
@@ -1,7 +1,7 @@
 {
     "twitter": [{
         "name": "regular video",
-        "url": "https://twitter.com/XSpaces/status/1526955853743546372?s=20",
+        "url": "https://twitter.com/X/status/1697304622749086011",
         "params": {
             "aFormat": "mp3",
             "isAudioOnly": false,
@@ -14,7 +14,7 @@
     },
     {
         "name": "video with mobile web mediaviewer",
-        "url": "https://twitter.com/XSpaces/status/1526955853743546372/mediaViewer?currentTweet=1526955853743546372&currentTweetUser=XSpaces&currentTweet=1526955853743546372&currentTweetUser=XSpaces",
+        "url": "https://twitter.com/X/status/1697304622749086011/mediaViewer?currentTweet=1697304622749086011&currentTweetUser=X&currentTweet=1697304622749086011&currentTweetUser=X",
         "params": {},
         "expected": {
             "code": 200,


### PR DESCRIPTION
This fixes 2 of the Twitter links. 
* `TwitterSpaces` account is now `XSpaces`, was failing the test before. Renaming fixes it.
* The `Twitter` account is private, so the mixed media test was failing. This replaces it with a random tweet I found that has a photo, video, and gif.