### PR TITLE
Fix instagram reels download

### DIFF
--- a/src/modules/processing/services/instagram.js
+++ b/src/modules/processing/services/instagram.js
@@ -142,25 +142,23 @@ export default function(obj) {
         if (cookie) {
             dtsgId = await findDtsgId(cookie);
         }
-        const url = new URL('https://www.instagram.com/api/graphql/');
+        const url = new URL('https://www.instagram.com/graphql/query');
 
         const requestData = {
-            jazoest: '26406',
+            jazoest: '2947',
             variables: JSON.stringify({
             shortcode: id,
             __relay_internal__pv__PolarisShareMenurelayprovider: false
             }),
-            doc_id: '7153618348081770'
+            doc_id: '25531498899829322'
         };
         if (dtsgId) {
             requestData.fb_dtsg = dtsgId;
         }
 
         return (await request(url, cookie, 'POST', requestData))
-                .data
-                ?.xdt_api__v1__media__shortcode__web_info
-                ?.items
-                ?.[0];
+        .data
+        ?.xdt_shortcode_media;
     }
 
     function extractOldPost(data, id) {
@@ -239,6 +237,10 @@ export default function(obj) {
                 urls: data.image_versions2.candidates[0].url,
                 isPhoto: true
             }
+        } else if(data.video_url) {
+            return {
+                urls: data.video_url,
+            }
         }
     }
 
@@ -266,6 +268,7 @@ export default function(obj) {
             if (!data) data = await requestHTML(id);
             if (!data && cookie) data = await requestHTML(id, cookie);
 
+            if(Object.keys(data).length == 2 && !data.gql_data && data.context) data = false;
             // web app graphql api (no cookie, cookie)
             if (!data) data = await requestGQL(id);
             if (!data && cookie) data = await requestGQL(id, cookie);


### PR DESCRIPTION
Dirty fix that requires more testing.
Checked locally, and could download reels from both #539 and #646. (some of them seem to be region locked tho, as I couldn't check them)
Previous graphql endpoint is return html page. I didn't test
It seems Instagram's old graphql endpoint is not working and data from html request is not good.
![image](https://github.com/user-attachments/assets/fc0ae51f-e84f-401c-9acc-ebc2efd805c0)
