### PR TITLE
feat: api route for best audio only

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -53,6 +53,13 @@ item type: `object`
 | `url`   | `string` | direct link to a file or a link to cobalt's live render |                                        |
 | `thumb` | `string` | item thumbnail that's displayed in the picker           | used for `video` and `gif` types       |
 
+## GET: `/api/best_audio`
+cobalt's best audio endpoint. this endpoint purely fetches the best audio available in any format without re-encoding, and redirects you to the download URL for the audio file. The query paramater `url` is required.
+
+```
+⚠️ Ensure that the `url` parameter is properly encoded before making the request.
+```
+
 ## GET: `/api/stream`
 cobalt's live render (or stream) endpoint. usually, you will receive a url to this endpoint
 from a successful call to `/api/json`. however, the parameters passed to it are **opaque**

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -143,6 +143,32 @@ export function runAPI(express, app, gitCommit, gitBranch, __dirname) {
         }
     })
 
+    app.get('/api/best_audio', async (req, res) => {
+
+        if (!req.query.url) { return res.status(400).send('Missing required "url" query parameter'); }
+
+        const request = req.query;
+        request.aFormat = "best";
+        request.isAudioOnly = true;
+
+        const normalizedRequest = normalizeRequest(request);
+        if (!normalizedRequest) {
+            return fail('ErrorCantProcess');
+        }
+
+        const parsed = extract(normalizedRequest.url);
+        if (parsed === null) {
+            return fail('ErrorUnsupported');
+        }
+
+        try {
+            const result = await match(parsed.host, parsed.patternMatch, false, normalizedRequest);
+            res.status(302).set('Location', result.body.url).end();
+        } catch {
+            fail('ErrorSomethingWentWrong');
+        }
+    })
+    
     app.get('/api/stream', (req, res) => {
         const id = String(req.query.id);
         const exp = String(req.query.exp);

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -145,6 +145,13 @@ export function runAPI(express, app, gitCommit, gitBranch, __dirname) {
 
     app.get('/api/best_audio', async (req, res) => {
 
+        const lang = languageCode(req);
+
+        const fail = (t) => {
+            const { status, body } = createResponse("error", { t: loc(lang, t) });
+            res.status(status).json(body);
+        }
+        
         if (!req.query.url) { return res.status(400).send('Missing required "url" query parameter'); }
 
         const request = req.query;
@@ -168,7 +175,7 @@ export function runAPI(express, app, gitCommit, gitBranch, __dirname) {
             fail('ErrorSomethingWentWrong');
         }
     })
-    
+
     app.get('/api/stream', (req, res) => {
         const id = String(req.query.id);
         const exp = String(req.query.exp);


### PR DESCRIPTION
Mostly solves issues #707 and #708.

Adds an endpoint to directly get a link to the best available audio.
Tested with a YouTube Video and Instagram photo. Example Endpoint URLs:

http://localhost:9000/api/best_audio?url=https://www.youtube.com/watch?v=wcT7zgL6gug
http://localhost:9000/api/best_audio?url=https://www.threads.net/@soren.iverson/post/C8PdJ59pMLr
