### PR TITLE
Discord embed now has a black stripe for cobalt.tools

### DIFF
--- a/web/src/app.html
+++ b/web/src/app.html
@@ -6,6 +6,7 @@
         <meta name="application-name" content="cobalt">
         <meta name="og:type" content="article">
         <meta name="twitter:card" content="summary">
+        <meta name="theme-color" content="#000000">
 
         %sveltekit.head%
 


### PR DESCRIPTION
Simple one-line change that makes the little stripe on cobalt embeds black instead of the default.
![image](https://github.com/user-attachments/assets/7efd8d63-2c38-4472-ae1d-f898d517465b)

