### PR TITLE
web/layout: increase toggle contrast in dark mode

### DIFF
--- a/web/src/components/misc/Toggle.svelte
+++ b/web/src/components/misc/Toggle.svelte
@@ -33,7 +33,7 @@
     }
 
     .toggle.enabled {
-        background: var(--green);
+        background: var(--toggle-bg-enabled);
     }
 
     .toggle.enabled .toggle-switcher {

--- a/web/src/components/misc/Toggle.svelte
+++ b/web/src/components/misc/Toggle.svelte
@@ -33,7 +33,7 @@
     }
 
     .toggle.enabled {
-        background: var(--toggle-bg-enabled);
+        background: var(--green);
     }
 
     .toggle.enabled .toggle-switcher {

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -196,7 +196,7 @@
         --input-border: #383838;
 
         --toggle-bg: var(--input-border);
-        --toggle-bg-enabled: #777777;
+        --toggle-bg-enabled: var(--green);
 
         --sidebar-mobile-gradient: linear-gradient(
             90deg,

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -196,7 +196,7 @@
         --input-border: #383838;
 
         --toggle-bg: var(--input-border);
-        --toggle-bg-enabled: var(--green);
+        --toggle-bg-enabled: #8a8a8a;
 
         --sidebar-mobile-gradient: linear-gradient(
             90deg,


### PR DESCRIPTION
- Use `var(--green)` as active background color
  - There is currently a good amount of difficulty in determining which toggles are enabled and disabled, especially for the visually impaired. I propose we use an active color with more contrast to the inactive color.  

<img width="614" alt="Screenshot 2024-09-16 at 7 38 07 AM" src="https://github.com/user-attachments/assets/2bd77e78-75bc-4eec-bf3f-478e43cb6d26">

<img width="604" alt="Screenshot 2024-09-16 at 7 38 13 AM" src="https://github.com/user-attachments/assets/eb820d9e-3d12-429c-9640-7d5b43194b0e">
