### PR TITLE
Spellcheck: Tweak spelling for various tenses of `tunnel`

### DIFF
--- a/web/i18n/en/settings.json
+++ b/web/i18n/en/settings.json
@@ -65,7 +65,7 @@
     "metadata.filename.basic": "basic",
     "metadata.filename.pretty": "pretty",
     "metadata.filename.nerdy": "nerdy",
-    "metadata.filename.description": "filename style will only be used for files tunnelled by cobalt. some services don't support filename styles other than classic.",
+    "metadata.filename.description": "filename style will only be used for files tunneled by cobalt. some services don't support filename styles other than classic.",
 
     "metadata.filename.preview.video": "Video Title",
     "metadata.filename.preview.audio": "Audio Title - Audio Author",
@@ -98,7 +98,7 @@
     "privacy.analytics.description": "anonymous traffic analytics are needed to get an approximate number of active cobalt users. no identifiable information about you is ever stored. all processed data is anonymized and aggregated.\n\nwe use a self-hosted plausible instance that doesn't use cookies and is fully compliant with GDPR, CCPA, and PECR.",
     "privacy.analytics.learnmore": "learn more about plausible's dedication to privacy.",
 
-    "privacy.tunnel": "tunnelling",
+    "privacy.tunnel": "tunneling",
     "privacy.tunnel.title": "always tunnel files",
     "privacy.tunnel.description": "cobalt will hide your ip address, browser info, and bypass local network restrictions. when enabled, files will also have readable filenames that otherwise would be gibberish.",
 

--- a/web/src/routes/about/privacy/+page.svelte
+++ b/web/src/routes/about/privacy/+page.svelte
@@ -25,10 +25,10 @@
     <section id="saving">
         <h3>saving</h3>
         <p>
-            when using saving functionality, in some cases cobalt will encrypt & temporarily store information needed for tunnelling. it's stored in processing server's RAM for 90 seconds and irreversibly purged afterwards. no one has access to it, even instance owners, as long as they don't modify the official cobalt image.
+            when using saving functionality, in some cases cobalt will encrypt & temporarily store information needed for tunneling. it's stored in processing server's RAM for 90 seconds and irreversibly purged afterwards. no one has access to it, even instance owners, as long as they don't modify the official cobalt image.
         </p>
         <p>
-            processed/tunnelled files are never cached anywhere. everything is tunnelled live. cobalt's saving functionality is essentially a fancy proxy service.
+            processed/tunneled files are never cached anywhere. everything is tunneled live. cobalt's saving functionality is essentially a fancy proxy service.
         </p>
     </section>
 


### PR DESCRIPTION
- Tweak spelling for various tenses of `tunnel`
  - When used in the networking sense, it is much more common to use the American version which uses one L.