### PR TITLE
web/settings/audio: show bitrate selection as disabled when not applicable

### DIFF
--- a/web/i18n/en/settings.json
+++ b/web/i18n/en/settings.json
@@ -50,7 +50,7 @@
 
     "audio.bitrate": "audio bitrate",
     "audio.bitrate.kbps": "kb/s",
-    "audio.bitrate.description": "bitrate applies only to audio conversion. cobalt can't improve the source audio quality, so choosing a bitrate over 128kbps may inflate the file size with no audible difference. perceived quality may vary by format.",
+    "audio.bitrate.description": "bitrate only applies to audio conversion into lossy audio formats. cobalt can't improve the source audio quality, so choosing a bitrate over 128kbps may inflate the file size with no audible difference. perceived quality may vary by format.",
 
     "audio.youtube.dub": "youtube",
     "audio.youtube.dub.title": "use browser language for dubbed videos",

--- a/web/src/routes/settings/audio/+page.svelte
+++ b/web/src/routes/settings/audio/+page.svelte
@@ -7,6 +7,7 @@
     import Switcher from "$components/buttons/Switcher.svelte";
     import SettingsButton from "$components/buttons/SettingsButton.svelte";
     import SettingsToggle from "$components/buttons/SettingsToggle.svelte";
+    import settings from "$lib/state/settings"
 </script>
 
 <SettingsCategory sectionId="format" title={$t("settings.audio.format")}>
@@ -23,7 +24,7 @@
     </Switcher>
 </SettingsCategory>
 
-<SettingsCategory sectionId="bitrate" title={$t("settings.audio.bitrate")}>
+<SettingsCategory sectionId="bitrate" title={$t("settings.audio.bitrate")} disabled={["wav", "best"].includes($settings.save.audioFormat)}>
     <Switcher big={true} description={$t("settings.audio.bitrate.description")}>
         {#each audioBitrateOptions as value}
             <SettingsButton


### PR DESCRIPTION
if the audio format is either `best` or `wav` the bitrate selector is greyed-out, because it's lossless or not necessarily re-encoded.