### PR TITLE
api/url: extract loom video id from longer links

### DIFF
--- a/api/src/processing/url.js
+++ b/api/src/processing/url.js
@@ -98,6 +98,15 @@ function aliasURL(url) {
             if (url.hostname === 'xhslink.com' && parts.length === 3) {
                 url = new URL(`https://www.xiaohongshu.com/a/${parts[2]}`);
             }
+            break;
+
+        case "loom":
+            const idPart = parts[parts.length - 1];
+            if(idPart.length > 32){
+                const actualIdPart = idPart.slice(-32);
+                url.pathname = `/share/${actualIdPart}`;
+            }
+            break;
     }
 
     return url;

--- a/api/src/processing/url.js
+++ b/api/src/processing/url.js
@@ -102,9 +102,8 @@ function aliasURL(url) {
 
         case "loom":
             const idPart = parts[parts.length - 1];
-            if(idPart.length > 32){
-                const actualIdPart = idPart.slice(-32);
-                url.pathname = `/share/${actualIdPart}`;
+            if (idPart.length > 32) {
+                url.pathname = `/share/${idPart.slice(-32)}`;
             }
             break;
     }


### PR DESCRIPTION
## Background
This is in response to #799.

It's not really a bug, but the original code intended the ID for Loom videos to be at most 32 characters. For example, `https://www.loom.com/share/4a2a8baf124c4390954dcbb46a58cfd7`.

However, apparently Loom has a longer URL variant that has the title encoded as well such as `https://www.loom.com/share/Unlocking-Incredible-Organizational-Velocity-with-Async-Video-4a2a8baf124c4390954dcbb46a58cfd7`.

However, I did notice that in this longer variant URL form, the URL actually contains the ID right at the end of the path. For example in `https://www.loom.com/share/Unlocking-Incredible-Organizational-Velocity-with-Async-Video-4a2a8baf124c4390954dcbb46a58cfd7`, the ID of the video is `4a2a8baf124c4390954dcbb46a58cfd7`.

## Solving Attempt
So, what I did is pretty much utilize the function `aliasURL` in `url.js` to provide support for this URL variant. Then, I changed the URL pathname to the correct format so the patternMatch is the exact ID to be later on tested by the tester pattern by extracting the last 32 characters from the supposed `id` containing more than 32 characters. Here's the code mentioned.

```Javascript
case "loom":
    const idPart = parts[parts.length - 1];
    if(idPart.length > 32){
        const actualIdPart = idPart.slice(-32);
        url.pathname = `/share/${actualIdPart}`;
    }
    break;
```

## Test Result
I've done a manual test using Yaak and it succeeds in the supposedly unyielding URLs.
![image](https://github.com/user-attachments/assets/17369c05-ecc6-4d00-b35f-10bcd3632556)

I've run `npm run test` as well and met some failures in reddit, streamable, and vimeo test cases but this is because those sites are banned in my country. It shouldn't affect those at all though.