### PR TITLE
fix `failed to solve: source can't be a git ref for COPY`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ FROM base AS api
 WORKDIR /app
 
 COPY --from=build /prod/api /app
-COPY --from=build /app/.git /app/.git
+COPY --from=build /app/.git/logs/HEAD /app/.git/logs/HEAD
+COPY --from=build /app/.git/HEAD /app/.git/HEAD
+COPY --from=build /app/.git/config /app/.git/config
 
 EXPOSE 9000
 CMD [ "node", "src/cobalt" ]


### PR DESCRIPTION
```
[+] Building 1.5s (2/2) FINISHED                                                                                                                                                                    
 => [internal] load build definition from Dockerfile                                                                                                                                           0.8s
 => => transferring dockerfile: 561B                                                                                                                                                           0.8s
 => [internal] load metadata for docker.io/library/node:20-bullseye-slim                                                                                                                       0.4s
==> Building image
==> Building image with Depot
--> build:  (​)
[+] Building 1.3s (2/2) FINISHED                                                                                                                                                                    
 => [internal] load build definition from Dockerfile                                                                                                                                           0.8s
 => => transferring dockerfile: 561B                                                                                                                                                           0.8s
 => [internal] load metadata for docker.io/library/node:20-bullseye-slim                                                                                                                       0.3s
Error: failed to fetch an image or build from source: error building: failed to solve: source can't be a git ref for COPY
```

When I run `docker build`, I get a strange error: `failed to solve: source can't be a git ref for COPY`. This error only disappears if I specify exact directories or files within the .git folder.