### PR TITLE
multi-process concurrent cobalt instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bullseye-slim AS base
+FROM node:23-bullseye-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 

--- a/api/package.json
+++ b/api/package.json
@@ -31,7 +31,7 @@
         "dotenv": "^16.0.1",
         "esbuild": "^0.14.51",
         "express": "^4.21.0",
-        "express-rate-limit": "^6.3.0",
+        "express-rate-limit": "^7.4.1",
         "ffmpeg-static": "^5.1.0",
         "hls-parser": "^0.10.7",
         "ipaddr.js": "2.2.0",

--- a/api/package.json
+++ b/api/package.json
@@ -24,6 +24,7 @@
     },
     "homepage": "https://github.com/imputnet/cobalt#readme",
     "dependencies": {
+        "@datastructures-js/priority-queue": "^6.3.1",
         "@imput/version-info": "workspace:^",
         "content-disposition-header": "0.6.0",
         "cors": "^2.8.5",

--- a/api/package.json
+++ b/api/package.json
@@ -46,6 +46,7 @@
     },
     "optionalDependencies": {
         "freebind": "^0.2.2",
+        "rate-limit-redis": "^4.2.0",
         "redis": "^4.7.0"
     }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -44,6 +44,7 @@
         "zod": "^3.23.8"
     },
     "optionalDependencies": {
-        "freebind": "^0.2.2"
+        "freebind": "^0.2.2",
+        "redis": "^4.7.0"
     }
 }

--- a/api/src/cobalt.js
+++ b/api/src/cobalt.js
@@ -20,7 +20,7 @@ app.disable("x-powered-by");
 if (env.apiURL) {
     const { runAPI } = await import("./core/api.js");
 
-    if (cluster.isPrimary && isCluster) {
+    if (isCluster) {
         initCluster();
     }
 

--- a/api/src/cobalt.js
+++ b/api/src/cobalt.js
@@ -21,7 +21,7 @@ if (env.apiURL) {
     const { runAPI } = await import("./core/api.js");
 
     if (isCluster) {
-        initCluster();
+       await initCluster();
     }
 
     runAPI(express, app, __dirname, cluster.isPrimary);

--- a/api/src/cobalt.js
+++ b/api/src/cobalt.js
@@ -1,12 +1,14 @@
 import "dotenv/config";
 
 import express from "express";
+import cluster from "node:cluster";
 
 import path from "path";
 import { fileURLToPath } from "url";
 
-import { env } from "./config.js"
+import { env, isCluster } from "./config.js"
 import { Red } from "./misc/console-text.js";
+import { initCluster } from "./misc/cluster.js";
 
 const app = express();
 
@@ -17,7 +19,12 @@ app.disable("x-powered-by");
 
 if (env.apiURL) {
     const { runAPI } = await import("./core/api.js");
-    runAPI(express, app, __dirname)
+
+    if (cluster.isPrimary && isCluster) {
+        initCluster();
+    }
+
+    runAPI(express, app, __dirname, cluster.isPrimary);
 } else {
     console.log(
         Red("API_URL env variable is missing, cobalt api can't start.")

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -45,6 +45,7 @@ const env = {
 
     apiKeyURL: process.env.API_KEY_URL && new URL(process.env.API_KEY_URL),
     authRequired: process.env.API_AUTH_REQUIRED === '1',
+    redisURL: process.env.API_REDIS_URL,
 
     keyReloadInterval: 900,
 

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -55,6 +55,9 @@ const env = {
 const genericUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36";
 const cobaltUserAgent = `cobalt/${version} (+https://github.com/imputnet/cobalt)`;
 
+export let tunnelPort = env.apiPort;
+export const setTunnelPort = (port) => tunnelPort = port;
+
 if (env.sessionEnabled && env.jwtSecret.length < 16) {
     throw new Error("JWT_SECRET env is too short (must be at least 16 characters long)");
 }

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -62,7 +62,9 @@ export const isCluster = env.instanceCount > 1;
 
 if (env.sessionEnabled && env.jwtSecret.length < 16) {
     throw new Error("JWT_SECRET env is too short (must be at least 16 characters long)");
-} else if (env.instanceCount > 1 && !env.redisURL) {
+}
+
+if (env.instanceCount > 1 && !env.redisURL) {
     throw new Error("API_REDIS_URL is required when API_INSTANCE_COUNT is >= 2");
 } else if (env.instanceCount > 1 && !await supportsReusePort()) {
     console.error('API_INSTANCE_COUNT is not supported in your environment. to use this env, your node.js');

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -14,6 +14,7 @@ const enabledServices = new Set(Object.keys(services).filter(e => {
 const env = {
     apiURL: process.env.API_URL || '',
     apiPort: process.env.API_PORT || 9000,
+    tunnelPort: process.env.API_PORT || 9000,
 
     listenAddress: process.env.API_LISTEN_ADDRESS,
     freebindCIDR: process.platform === 'linux' && process.env.FREEBIND_CIDR,
@@ -56,8 +57,7 @@ const env = {
 const genericUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36";
 const cobaltUserAgent = `cobalt/${version} (+https://github.com/imputnet/cobalt)`;
 
-export let tunnelPort = env.apiPort;
-export const setTunnelPort = (port) => tunnelPort = port;
+export const setTunnelPort = (port) => env.tunnelPort = port;
 export const isCluster = env.instanceCount > 1;
 
 if (env.sessionEnabled && env.jwtSecret.length < 16) {

--- a/api/src/core/api.js
+++ b/api/src/core/api.js
@@ -257,7 +257,7 @@ export const runAPI = (express, app, __dirname) => {
         }
     })
 
-    app.get('/tunnel', apiTunnelLimiter, (req, res) => {
+    app.get('/tunnel', apiTunnelLimiter, async (req, res) => {
         const id = String(req.query.id);
         const exp = String(req.query.exp);
         const sig = String(req.query.sig);
@@ -276,7 +276,7 @@ export const runAPI = (express, app, __dirname) => {
             return res.status(200).end();
         }
 
-        const streamInfo = verifyStream(id, sig, exp, sec, iv);
+        const streamInfo = await verifyStream(id, sig, exp, sec, iv);
         if (!streamInfo?.service) {
             return res.status(streamInfo.status).end();
         }

--- a/api/src/core/api.js
+++ b/api/src/core/api.js
@@ -8,7 +8,7 @@ import jwt from "../security/jwt.js";
 import stream from "../stream/stream.js";
 import match from "../processing/match.js";
 
-import { env, setTunnelPort } from "../config.js";
+import { env, isCluster, setTunnelPort } from "../config.js";
 import { extract } from "../processing/url.js";
 import { Green, Bright, Cyan } from "../misc/console-text.js";
 import { hashHmac } from "../security/secrets.js";
@@ -378,7 +378,7 @@ export const runAPI = async (express, app, __dirname, isPrimary = true) => {
         }
     });
 
-    if (!isPrimary) {
+    if (isCluster) {
         const istreamer = express();
         istreamer.get('/itunnel', itunnelHandler);
         const server = istreamer.listen({

--- a/api/src/misc/cluster.js
+++ b/api/src/misc/cluster.js
@@ -1,7 +1,9 @@
 import cluster from "node:cluster";
 import net from "node:net";
 import { syncSecrets } from "../security/secrets.js";
-import { env } from "../config.js";
+import { env, isCluster } from "../config.js";
+
+export { isPrimary, isWorker } from "node:cluster";
 
 export const supportsReusePort = async () => {
     try {
@@ -25,4 +27,14 @@ export const initCluster = async () => {
     }
 
     await syncSecrets();
+}
+
+export const broadcast = (message) => {
+    if (!isCluster || !cluster.isPrimary || !cluster.workers) {
+        return;
+    }
+
+    for (const worker of Object.values(cluster.workers)) {
+        worker.send(message);
+    }
 }

--- a/api/src/misc/cluster.js
+++ b/api/src/misc/cluster.js
@@ -1,0 +1,29 @@
+import net from "node:net";
+import cluster from "node:cluster";
+import { isCluster } from "../config.js";
+
+export const supportsReusePort = async () => {
+    try {
+        await new Promise((resolve, reject) => {
+            const server = net.createServer().listen({ port: 0, reusePort: true });
+            server.on('listening', () => server.close(resolve));
+            server.on('error', (err) => (server.close(), reject(err)));
+        });
+
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export const initCluster = async () => {
+    const { getSalt } = await import("../stream/manage.js");
+    const salt = getSalt();
+
+    for (let i = 1; i < env.instanceCount; ++i) {
+        const worker = cluster.fork();
+        worker.once('message', () => {
+            worker.send({ salt });
+        });
+    }
+}

--- a/api/src/misc/crypto.js
+++ b/api/src/misc/crypto.js
@@ -1,14 +1,6 @@
-import { createHmac, createCipheriv, createDecipheriv, randomBytes } from "crypto";
+import { createCipheriv, createDecipheriv } from "crypto";
 
 const algorithm = "aes256";
-
-export function generateSalt() {
-    return randomBytes(64);
-}
-
-export function generateHmac(str, salt) {
-    return createHmac("sha256", salt).update(str).digest("base64url");
-}
 
 export function encryptStream(plaintext, iv, secret) {
     const buff = Buffer.from(JSON.stringify(plaintext));

--- a/api/src/misc/crypto.js
+++ b/api/src/misc/crypto.js
@@ -3,7 +3,7 @@ import { createHmac, createCipheriv, createDecipheriv, randomBytes } from "crypt
 const algorithm = "aes256";
 
 export function generateSalt() {
-    return randomBytes(64).toString('hex');
+    return randomBytes(64);
 }
 
 export function generateHmac(str, salt) {

--- a/api/src/processing/cookie/cookie.js
+++ b/api/src/processing/cookie/cookie.js
@@ -6,14 +6,17 @@ export default class Cookie {
         this._values = {};
         this.set(input)
     }
+
     set(values) {
         Object.entries(values).forEach(
             ([ key, value ]) => this._values[key] = value
         )
     }
+
     unset(keys) {
         for (const key of keys) delete this._values[key]
     }
+
     static fromString(str) {
         const obj = {};
 
@@ -25,12 +28,15 @@ export default class Cookie {
 
         return new Cookie(obj)
     }
+
     toString() {
         return Object.entries(this._values).map(([ name, value ]) => `${name}=${value}`).join('; ')
     }
+
     toJSON() {
         return this.toString()
     }
+
     values() {
         return Object.freeze({ ...this._values })
     }

--- a/api/src/processing/cookie/cookie.js
+++ b/api/src/processing/cookie/cookie.js
@@ -4,13 +4,18 @@ export default class Cookie {
     constructor(input) {
         assert(typeof input === 'object');
         this._values = {};
-        this.set(input)
+
+        for (const [ k, v ] of Object.entries(input))
+            this.set(k, v);
     }
 
-    set(values) {
-        Object.entries(values).forEach(
-            ([ key, value ]) => this._values[key] = value
-        )
+    set(key, value) {
+        const old = this._values[key];
+        if (old === value)
+            return false;
+
+        this._values[key] = value;
+        return true;
     }
 
     unset(keys) {

--- a/api/src/processing/cookie/manager.js
+++ b/api/src/processing/cookie/manager.js
@@ -4,9 +4,7 @@ import { readFile, writeFile } from 'fs/promises';
 import { Green, Yellow } from '../../misc/console-text.js';
 import { parse as parseSetCookie, splitCookiesString } from 'set-cookie-parser';
 
-const WRITE_INTERVAL = 60000,
-      COUNTER = Symbol('counter');
-
+const WRITE_INTERVAL = 60000;
 let cookies = {}, dirty = false, intervalId;
 
 function writeChanges(cookiePath) {
@@ -33,18 +31,14 @@ export const setup = async (cookiePath) => {
 export function getCookie(service) {
     if (!cookies[service] || !cookies[service].length) return;
 
-    let n;
-    if (cookies[service][COUNTER] === undefined) {
-        n = cookies[service][COUNTER] = 0
-    } else {
-        ++cookies[service][COUNTER]
-        n = (cookies[service][COUNTER] %= cookies[service].length)
+    const idx = Math.floor(Math.random() * cookies[service].length);
+
+    const cookie = cookies[service][idx];
+    if (typeof cookie === 'string') {
+        cookies[service][idx] = Cookie.fromString(cookie);
     }
 
-    const cookie = cookies[service][n];
-    if (typeof cookie === 'string') cookies[service][n] = Cookie.fromString(cookie);
-
-    return cookies[service][n]
+    return cookies[service][idx];
 }
 
 export function updateCookieValues(cookie, values) {

--- a/api/src/processing/cookie/manager.js
+++ b/api/src/processing/cookie/manager.js
@@ -42,8 +42,17 @@ export function getCookie(service) {
 }
 
 export function updateCookieValues(cookie, values) {
-    cookie.set(values);
-    if (Object.keys(values).length) dirty = true
+    let changed = false;
+
+    for (const [ key, value ] of Object.entries(values)) {
+        changed ||= cookie.set(key, value);
+    }
+
+    if (changed) {
+        dirty = true;
+    }
+
+    return changed;
 }
 
 export function updateCookie(cookie, headers) {

--- a/api/src/processing/services/bluesky.js
+++ b/api/src/processing/services/bluesky.js
@@ -48,7 +48,7 @@ const extractImages = ({ getPost, filename, alwaysProxy }) => {
         let proxiedImage = createStream({
             service: "bluesky",
             type: "proxy",
-            u: url,
+            url,
             filename: `${filename}_${i + 1}.jpg`,
         });
 

--- a/api/src/processing/services/instagram.js
+++ b/api/src/processing/services/instagram.js
@@ -177,7 +177,7 @@ export default function(obj) {
                     if (alwaysProxy) proxyFile = createStream({
                         service: "instagram",
                         type: "proxy",
-                        u: url,
+                        url,
                         filename: `instagram_${id}_${i + 1}.${itemExt}`
                     });
 
@@ -189,7 +189,7 @@ export default function(obj) {
                         thumb: createStream({
                             service: "instagram",
                             type: "proxy",
-                            u: e.node?.display_url,
+                            url: e.node?.display_url,
                             filename: `instagram_${id}_${i + 1}.jpg`
                         })
                     }
@@ -230,7 +230,7 @@ export default function(obj) {
                     if (alwaysProxy) proxyFile = createStream({
                         service: "instagram",
                         type: "proxy",
-                        u: url,
+                        url,
                         filename: `instagram_${id}_${i + 1}.${itemExt}`
                     });
 
@@ -242,7 +242,7 @@ export default function(obj) {
                         thumb: createStream({
                             service: "instagram",
                             type: "proxy",
-                            u: imageUrl,
+                            url: imageUrl,
                             filename: `instagram_${id}_${i + 1}.jpg`
                         })
                     }

--- a/api/src/processing/services/snapchat.js
+++ b/api/src/processing/services/snapchat.js
@@ -73,7 +73,7 @@ async function getStory(username, storyId, alwaysProxy) {
                     const proxy = createStream({
                         service: "snapchat",
                         type: "proxy",
-                        u: snapUrl,
+                        url: snapUrl,
                         filename: `snapchat_${username}_${snap.timestampInSec.value}.${snapExt}`,
                     });
 
@@ -81,7 +81,7 @@ async function getStory(username, storyId, alwaysProxy) {
                     if (snapType === "video") thumbProxy = createStream({
                         service: "snapchat",
                         type: "proxy",
-                        u: snap.snapUrls.mediaPreviewUrl.value,
+                        url: snap.snapUrls.mediaPreviewUrl.value,
                     });
 
                     if (alwaysProxy) snapUrl = proxy;

--- a/api/src/processing/services/tiktok.js
+++ b/api/src/processing/services/tiktok.js
@@ -102,7 +102,7 @@ export default async function(obj) {
                 if (obj.alwaysProxy) url = createStream({
                     service: "tiktok",
                     type: "proxy",
-                    u: url,
+                    url,
                     filename: `${filenameBase}_photo_${i + 1}.jpg`
                 })
 

--- a/api/src/processing/services/twitter.js
+++ b/api/src/processing/services/twitter.js
@@ -159,10 +159,10 @@ export default async function({ id, index, toGif, dispatcher, alwaysProxy }) {
 
     const getFileExt = (url) => new URL(url).pathname.split(".", 2)[1];
 
-    const proxyMedia = (u, filename) => createStream({
+    const proxyMedia = (url, filename) => createStream({
         service: "twitter",
         type: "proxy",
-        u, filename,
+        url, filename,
     })
 
     switch (media?.length) {
@@ -217,7 +217,7 @@ export default async function({ id, index, toGif, dispatcher, alwaysProxy }) {
                     url = createStream({
                         service: "twitter",
                         type: shouldRenderGif ? "gif" : "remux",
-                        u: url,
+                        url,
                         filename: videoFilename,
                     })
                 } else if (alwaysProxy) {

--- a/api/src/security/api-keys.js
+++ b/api/src/security/api-keys.js
@@ -117,6 +117,10 @@ const formatKeys = (keyData) => {
     return formatted;
 }
 
+const updateKeys = (newKeys) => {
+    keys = formatKeys(newKeys);
+}
+
 const loadKeys = async (source) => {
     let updated;
     if (source.protocol === 'file:') {
@@ -136,10 +140,6 @@ const loadKeys = async (source) => {
     cluster.broadcast({ api_keys: updated });
 
     updateKeys(updated);
-}
-
-const updateKeys = (newKeys) => {
-    keys = formatKeys(newKeys);
 }
 
 const wrapLoad = (url, initial = false) => {

--- a/api/src/security/api-keys.js
+++ b/api/src/security/api-keys.js
@@ -1,8 +1,8 @@
-import { env, isCluster } from "../config.js";
+import { env } from "../config.js";
 import { readFile } from "node:fs/promises";
 import { Green, Yellow } from "../misc/console-text.js";
-import cluster from "node:cluster";
 import ip from "ipaddr.js";
+import * as cluster from "../misc/cluster.js";
 
 // this function is a modified variation of code
 // from https://stackoverflow.com/a/32402438/14855621
@@ -133,11 +133,7 @@ const loadKeys = async (source) => {
 
     validateKeys(updated);
 
-    if (isCluster && cluster.workers) {
-        for (const worker of Object.values(cluster.workers)) {
-            worker.send({ api_keys: updated });
-        }
-    }
+    cluster.broadcast({ api_keys: updated });
 
     updateKeys(updated);
 }

--- a/api/src/security/secrets.js
+++ b/api/src/security/secrets.js
@@ -1,0 +1,58 @@
+import cluster from "node:cluster";
+import { createHmac, randomBytes } from "node:crypto";
+
+const generateSalt = () => {
+    if (cluster.isPrimary)
+        return randomBytes(64);
+
+    return null;
+}
+
+let rateSalt = generateSalt();
+let streamSalt = generateSalt();
+
+export const syncSecrets = () => {
+    return new Promise((resolve, reject) => {
+        if (cluster.isPrimary) {
+            let remaining = Object.values(cluster.workers).length;
+
+            for (const worker of Object.values(cluster.workers)) {
+                worker.once('message', (m) => {
+                    if (m.ready)
+                        worker.send({ rateSalt, streamSalt });
+
+                    if (!--remaining)
+                        resolve();
+                });
+            }
+        } else if (cluster.isWorker) {
+            if (rateSalt || streamSalt)
+                return reject();
+
+            process.send({ ready: true });
+            process.once('message', (message) => {
+                if (rateSalt || streamSalt)
+                    return reject();
+
+                if (message.rateSalt && message.streamSalt) {
+                    streamSalt = Buffer.from(message.streamSalt);
+                    rateSalt = Buffer.from(message.rateSalt);
+                    resolve();
+                }
+            });
+        } else reject();
+    });
+}
+
+
+export const hashHmac = (value, type) => {
+    let salt;
+    if (type === 'rate')
+        salt = rateSalt;
+    else if (type === 'stream')
+        salt = streamSalt;
+    else
+        throw "unknown salt";
+
+    return createHmac("sha256", salt).update(value).digest();
+}

--- a/api/src/store/base-store.js
+++ b/api/src/store/base-store.js
@@ -1,0 +1,39 @@
+const _stores = new Set();
+
+export class Store {
+    id;
+
+    constructor(name) {
+        name = name.toUpperCase();
+
+        if (_stores.has(name))
+            throw `${name} store already exists`;
+        _stores.add(name);
+
+        this.id = name;
+    }
+
+    async _get(_key) { throw "needs implementation" }
+    async get(key) {
+        if (typeof key !== 'string') {
+            key = key.toString();
+        }
+
+        const val = await this._get(key);
+        if (val === null)
+            return null;
+
+        return val;
+    }
+
+    async _set(_key, _val, _exp_sec = -1) { throw "needs implementation" }
+    set(key, val, exp_sec = -1) {
+        if (typeof key !== 'string') {
+            key = key.toString();
+        }
+
+        exp_sec = Math.round(exp_sec);
+
+        return this._set(key, val, exp_sec);
+    }
+};

--- a/api/src/store/base-store.js
+++ b/api/src/store/base-store.js
@@ -13,7 +13,7 @@ export class Store {
         this.id = name;
     }
 
-    async _has(_key) { throw "needs implementation" }
+    async _has(_key) { await Promise.reject("needs implementation"); }
     has(key) {
         if (typeof key !== 'string') {
             key = key.toString();
@@ -22,7 +22,7 @@ export class Store {
         return this._has(key);
     }
 
-    async _get(_key) { throw "needs implementation" }
+    async _get(_key) { await Promise.reject("needs implementation"); }
     async get(key) {
         if (typeof key !== 'string') {
             key = key.toString();
@@ -35,7 +35,7 @@ export class Store {
         return val;
     }
 
-    async _set(_key, _val, _exp_sec = -1) { throw "needs implementation" }
+    async _set(_key, _val, _exp_sec = -1) { await Promise.reject("needs implementation") }
     set(key, val, exp_sec = -1) {
         if (typeof key !== 'string') {
             key = key.toString();

--- a/api/src/store/base-store.js
+++ b/api/src/store/base-store.js
@@ -13,6 +13,15 @@ export class Store {
         this.id = name;
     }
 
+    async _has(_key) { throw "needs implementation" }
+    has(key) {
+        if (typeof key !== 'string') {
+            key = key.toString();
+        }
+
+        return this._has(key);
+    }
+
     async _get(_key) { throw "needs implementation" }
     async get(key) {
         if (typeof key !== 'string') {

--- a/api/src/store/memory-store.js
+++ b/api/src/store/memory-store.js
@@ -14,6 +14,10 @@ export default class MemoryStore extends Store {
         super(name);
     }
 
+    async _has(key) {
+        return this.#store.has(key);
+    }
+
     async _get(key) {
         const val = this.#store.get(key);
 

--- a/api/src/store/memory-store.js
+++ b/api/src/store/memory-store.js
@@ -14,17 +14,17 @@ export default class MemoryStore extends Store {
         super(name);
     }
 
-    async _has(key) {
+    _has(key) {
         return this.#store.has(key);
     }
 
-    async _get(key) {
+    _get(key) {
         const val = this.#store.get(key);
 
         return val === undefined ? null : val;
     }
 
-    async _set(key, val, exp_sec = -1) {
+    _set(key, val, exp_sec = -1) {
         if (this.#store.has(key)) {
             this.#timeouts.remove(o => o.k === key);
         }

--- a/api/src/store/memory-store.js
+++ b/api/src/store/memory-store.js
@@ -1,0 +1,72 @@
+import { MinPriorityQueue } from '@datastructures-js/priority-queue'
+import { Store } from './base-store.js';
+
+// minimum delay between sweeps to avoid repeatedly
+// sweeping entries close in proximity one by one.
+const MIN_THRESHOLD_MS = 2500;
+
+export default class MemoryStore extends Store {
+    #store = new Map();
+    #timeouts = new MinPriorityQueue/*<{ t: number, k: unknown }>*/((obj) => obj.t);
+    #nextSweep = { id: null, t: null };
+
+    constructor(name) {
+        super(name);
+    }
+
+    async _get(key) {
+        const val = this.#store.get(key);
+
+        return val === undefined ? null : val;
+    }
+
+    async _set(key, val, exp_sec = -1) {
+        if (this.#store.has(key)) {
+            this.#timeouts.remove(o => o.k === key);
+        }
+
+        if (exp_sec > 0) {
+            const exp = 1000 * exp_sec;
+            const timeout_at = +new Date() + exp;
+
+            this.#timeouts.enqueue({ k: key, t: timeout_at });
+        }
+
+        this.#store.set(key, val);
+        this.#reschedule();
+    }
+
+    #reschedule() {
+        const current_time = new Date().getTime();
+        const time = this.#timeouts.front()?.t;
+        if (!time) {
+            return;
+        } else if (time < current_time) {
+            return this.#sweepNow();
+        }
+
+        const sweep = this.#nextSweep;
+        if (sweep.id === null || sweep.t > time) {
+            if (sweep.id) {
+                clearTimeout(sweep.id);
+            }
+
+            sweep.t = time;
+            sweep.id = setTimeout(
+                () => this.#sweepNow(),
+                Math.max(MIN_THRESHOLD_MS, time - current_time)
+            );
+        }
+    }
+
+    #sweepNow() {
+        while (this.#timeouts.front()?.t < new Date().getTime()) {
+            const item = this.#timeouts.dequeue();
+            this.#store.delete(item.k);
+        }
+
+        this.#nextSweep.id = null;
+        this.#nextSweep.t = null;
+        this.#reschedule();
+    }
+}

--- a/api/src/store/memory-store.js
+++ b/api/src/store/memory-store.js
@@ -1,4 +1,4 @@
-import { MinPriorityQueue } from '@datastructures-js/priority-queue'
+import { MinPriorityQueue } from '@datastructures-js/priority-queue';
 import { Store } from './base-store.js';
 
 // minimum delay between sweeps to avoid repeatedly

--- a/api/src/store/redis-ratelimit.js
+++ b/api/src/store/redis-ratelimit.js
@@ -1,0 +1,19 @@
+import { env } from "../config.js";
+
+let client, redis, redisLimiter;
+
+export const createStore = async (name) => {
+    if (!env.redisURL) return;
+
+    if (!client) {
+        redis = await import('redis');
+        redisLimiter = await import('rate-limit-redis');
+        client = redis.createClient({ url: env.redisURL });
+        await client.connect();
+    }
+
+    return new redisLimiter.default({
+        prefix: `RL${name}_`,
+        sendCommand: (...args) => client.sendCommand(args),
+    });
+}

--- a/api/src/store/redis-store.js
+++ b/api/src/store/redis-store.js
@@ -17,6 +17,12 @@ export default class RedisStore extends Store {
         return this.id + '_' + key;
     }
 
+    async _has(key) {
+        await this.#connected;
+
+        return this.#client.hExists(key);
+    }
+
     async _get(key) {
         await this.#connected;
 

--- a/api/src/store/redis-store.js
+++ b/api/src/store/redis-store.js
@@ -1,0 +1,62 @@
+import { commandOptions, createClient } from "redis";
+import { env } from "../config.js";
+import { Store } from "./base-store.js";
+
+export default class RedisStore extends Store {
+    #client = createClient({
+        url: env.redisURL,
+    });
+    #connected;
+
+    constructor(name) {
+        super(name);
+        this.#connected = this.#client.connect();
+    }
+
+    #keyOf(key) {
+        return this.id + '_' + key;
+    }
+
+    async _get(key) {
+        await this.#connected;
+
+        const data = await this.#client.hGetAll(
+            commandOptions({ returnBuffers: true }),
+            this.#keyOf(key)
+        );
+
+        if (!data.d) {
+            return null;
+        }
+
+        const type = data.t;
+        if (type && type[0] === 'b'.charCodeAt())
+            return data.d;
+        else
+            return JSON.parse(data.d);
+    }
+
+    async _set(key, val, exp_sec = -1) {
+        await this.#connected;
+
+        const out = { d: val };
+        if (val instanceof Buffer) {
+            out.t = 'b';
+        } else {
+            out.d = JSON.stringify(val);
+        }
+
+        await this.#client.hSet(
+            this.#keyOf(key),
+            out
+        );
+
+        if (exp_sec > 0) {
+            await this.#client.hExpire(
+                this.#keyOf(key),
+                Object.keys(out),
+                exp_sec
+            );
+        }
+    }
+}

--- a/api/src/store/store.js
+++ b/api/src/store/store.js
@@ -1,0 +1,10 @@
+import { env } from '../config.js';
+
+let _export;
+if (env.redisURL) {
+    _export = await import('./redis-store.js');
+} else {
+    _export = await import('./memory-store.js');
+}
+
+export default _export.default;

--- a/api/src/stream/manage.js
+++ b/api/src/stream/manage.js
@@ -5,7 +5,7 @@ import { randomBytes } from "crypto";
 import { strict as assert } from "assert";
 import { setMaxListeners } from "node:events";
 
-import { env, tunnelPort } from "../config.js";
+import { env } from "../config.js";
 import { closeRequest } from "./shared.js";
 import { decryptStream, encryptStream } from "../misc/crypto.js";
 import { hashHmac } from "../security/secrets.js";
@@ -102,7 +102,7 @@ export function createInternalStream(url, obj = {}) {
         isHLS: obj.isHLS,
     });
 
-    let streamLink = new URL('/itunnel', `http://127.0.0.1:${tunnelPort}`);
+    let streamLink = new URL('/itunnel', `http://127.0.0.1:${env.tunnelPort}`);
     streamLink.searchParams.set('id', streamID);
 
     const cleanup = () => {

--- a/api/src/stream/manage.js
+++ b/api/src/stream/manage.js
@@ -5,7 +5,7 @@ import { randomBytes } from "crypto";
 import { strict as assert } from "assert";
 import { setMaxListeners } from "node:events";
 
-import { env } from "../config.js";
+import { env, tunnelPort } from "../config.js";
 import { closeRequest } from "./shared.js";
 import { decryptStream, encryptStream, generateHmac } from "../misc/crypto.js";
 
@@ -102,7 +102,7 @@ export function createInternalStream(url, obj = {}) {
         isHLS: obj.isHLS,
     });
 
-    let streamLink = new URL('/itunnel', `http://127.0.0.1:${env.apiPort}`);
+    let streamLink = new URL('/itunnel', `http://127.0.0.1:${tunnelPort}`);
     streamLink.searchParams.set('id', streamID);
 
     const cleanup = () => {

--- a/api/src/stream/manage.js
+++ b/api/src/stream/manage.js
@@ -7,7 +7,7 @@ import { setMaxListeners } from "node:events";
 
 import { env, tunnelPort } from "../config.js";
 import { closeRequest } from "./shared.js";
-import { decryptStream, encryptStream, generateHmac } from "../misc/crypto.js";
+import { decryptStream, encryptStream, generateHmac, generateSalt } from "../misc/crypto.js";
 
 // optional dependency
 const freebind = env.freebindCIDR && await import('freebind').catch(() => {});
@@ -15,7 +15,7 @@ const freebind = env.freebindCIDR && await import('freebind').catch(() => {});
 const streamCache = new Store('streams');
 
 const internalStreamCache = new Map();
-const hmacSalt = randomBytes(64).toString('hex');
+const hmacSalt = generateSalt();
 
 export function createStream(obj) {
     const streamID = nanoid(),

--- a/api/src/util/test-ci.js
+++ b/api/src/util/test-ci.js
@@ -39,7 +39,7 @@ switch (action) {
             console.error('no such service:', service);
         }
 
-        env.streamLifespan = 10000;
+        env.streamLifespan = 3;
         env.apiURL = 'http://x';
         randomizeCiphers();
 

--- a/docs/run-an-instance.md
+++ b/docs/run-an-instance.md
@@ -77,6 +77,7 @@ sudo service nscd start
 | `JWT_EXPIRY`          | `120`     | `240`                  | the duration of how long a cobalt-issued JWT token will remain valid, in seconds. |
 | `API_KEY_URL`         | ➖        | `file://keys.json`      | the location of the api key database. for loading API keys, cobalt supports HTTP(S) urls, or local files by specifying a local path using the `file://` protocol. see the "api key file format" below for more details.  |
 | `API_AUTH_REQUIRED`   | ➖        | `1`                     | when set to `1`, the user always needs to be authenticated in some way before they can access the API (either via an api key or via turnstile, if enabled). |
+| `API_REDIS_URL`       | ➖        | `redis://localhost:6379` | when set, cobalt uses redis instead of internal memory for the tunnel cache. |
 
 \* the higher the nice value, the lower the priority. [read more here](https://en.wikipedia.org/wiki/Nice_(Unix)).
 

--- a/docs/run-an-instance.md
+++ b/docs/run-an-instance.md
@@ -78,6 +78,7 @@ sudo service nscd start
 | `API_KEY_URL`         | ➖        | `file://keys.json`      | the location of the api key database. for loading API keys, cobalt supports HTTP(S) urls, or local files by specifying a local path using the `file://` protocol. see the "api key file format" below for more details.  |
 | `API_AUTH_REQUIRED`   | ➖        | `1`                     | when set to `1`, the user always needs to be authenticated in some way before they can access the API (either via an api key or via turnstile, if enabled). |
 | `API_REDIS_URL`       | ➖        | `redis://localhost:6379` | when set, cobalt uses redis instead of internal memory for the tunnel cache. |
+| `API_INSTANCE_COUNT`  | ➖        | `2`                     | supported only on Linux and node.js `>=23.1.0`. when configured, cobalt will spawn multiple sub-instances amongst which requests will be balanced. |
 
 \* the higher the nice value, the lower the priority. [read more here](https://en.wikipedia.org/wiki/Nice_(Unix)).
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       express-rate-limit:
-        specifier: ^6.3.0
-        version: 6.11.2(express@4.21.0)
+        specifier: ^7.4.1
+        version: 7.4.1(express@4.21.0)
       ffmpeg-static:
         specifier: ^5.1.0
         version: 5.2.0
@@ -1298,11 +1298,11 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
-  express-rate-limit@6.11.2:
-    resolution: {integrity: sha512-a7uwwfNTh1U60ssiIkuLFWHt4hAC5yxlLGU2VP0X4YNlyEDZAqF4tK3GD3NSitVBrCQmQ0++0uOyFOgC2y4DDw==}
-    engines: {node: '>= 14'}
+  express-rate-limit@7.4.1:
+    resolution: {integrity: sha512-KS3efpnpIDVIXopMc65EMbWbUht7qvTCdtCR2dD/IZmi9MIkopYESwyRqLgv8Pfu589+KqDqOdzJWW7AHoACeg==}
+    engines: {node: '>= 16'}
     peerDependencies:
-      express: ^4 || ^5
+      express: 4 || 5 || ^5.0.0-beta.1
 
   express@4.21.0:
     resolution: {integrity: sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==}
@@ -3341,7 +3341,7 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
-  express-rate-limit@6.11.2(express@4.21.0):
+  express-rate-limit@7.4.1(express@4.21.0):
     dependencies:
       express: 4.21.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   api:
     dependencies:
+      '@datastructures-js/priority-queue':
+        specifier: ^6.3.1
+        version: 6.3.1
       '@imput/version-info':
         specifier: workspace:^
         version: link:../packages/version-info
@@ -187,6 +190,12 @@ packages:
 
   '@bufbuild/protobuf@2.1.0':
     resolution: {integrity: sha512-+2Mx67Y3skJ4NCD/qNSdBJNWtu6x6Qr53jeNg+QcwiL6mt0wK+3jwHH2x1p7xaYH6Ve2JKOVn0OxU35WsmqI9A==}
+
+  '@datastructures-js/heap@4.3.3':
+    resolution: {integrity: sha512-UcUu/DLh/aM4W3C8zZfwxxm6/6FIZUlm3mcAXuNOCa6Aj4iizNvNXQyb8DjZQH2jKSQbMRyNlngP6TPimuGjpQ==}
+
+  '@datastructures-js/priority-queue@6.3.1':
+    resolution: {integrity: sha512-eoxkWql/j0VJ0UFMFTpnyJz4KbEEVQ6aZ/JuJUgenu0Im4tYKylAycNGsYCHGXiVNEd7OKGVwfx1Ac3oYkuu7A==}
 
   '@derhuerst/http-basic@8.2.4':
     resolution: {integrity: sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==}
@@ -2354,6 +2363,12 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
 
   '@bufbuild/protobuf@2.1.0': {}
+
+  '@datastructures-js/heap@4.3.3': {}
+
+  '@datastructures-js/priority-queue@6.3.1':
+    dependencies:
+      '@datastructures-js/heap': 4.3.3
 
   '@derhuerst/http-basic@8.2.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       freebind:
         specifier: ^0.2.2
         version: 0.2.2
+      rate-limit-redis:
+        specifier: ^4.2.0
+        version: 4.2.0(express-rate-limit@7.4.1(express@4.21.0))
       redis:
         specifier: ^4.7.0
         version: 4.7.0
@@ -1876,6 +1879,12 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  rate-limit-redis@4.2.0:
+    resolution: {integrity: sha512-wV450NQyKC24NmPosJb2131RoczLdfIJdKCReNwtVpm5998U8SgKrAZrIHaN/NfQgqOHaan8Uq++B4sa5REwjA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express-rate-limit: '>= 6'
 
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
@@ -3867,6 +3876,11 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   range-parser@1.2.1: {}
+
+  rate-limit-redis@4.2.0(express-rate-limit@7.4.1(express@4.21.0)):
+    dependencies:
+      express-rate-limit: 7.4.1(express@4.21.0)
+    optional: true
 
   raw-body@2.5.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       freebind:
         specifier: ^0.2.2
         version: 0.2.2
+      redis:
+        specifier: ^4.7.0
+        version: 4.7.0
 
   packages/api-client:
     devDependencies:
@@ -569,6 +572,35 @@ packages:
   '@polka/url@1.0.0-next.25':
     resolution: {integrity: sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==}
 
+  '@redis/bloom@1.2.0':
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/client@1.6.0':
+    resolution: {integrity: sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==}
+    engines: {node: '>=14'}
+
+  '@redis/graph@1.1.1':
+    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/json@1.0.7':
+    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/search@1.2.0':
+    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/time-series@1.1.0':
+    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
   '@rollup/rollup-android-arm-eabi@4.24.0':
     resolution: {integrity: sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==}
     cpu: [arm]
@@ -915,6 +947,10 @@ packages:
     resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
     engines: {node: '>=0.8'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   code-red@1.0.4:
     resolution: {integrity: sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==}
 
@@ -1216,6 +1252,7 @@ packages:
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   esm-env@1.0.0:
@@ -1338,6 +1375,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
 
   get-intrinsic@1.2.4:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
@@ -1839,6 +1880,9 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  redis@4.7.0:
+    resolution: {integrity: sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2289,6 +2333,9 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2548,6 +2595,38 @@ snapshots:
     optional: true
 
   '@polka/url@1.0.0-next.25': {}
+
+  '@redis/bloom@1.2.0(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+    optional: true
+
+  '@redis/client@1.6.0':
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+    optional: true
+
+  '@redis/graph@1.1.1(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+    optional: true
+
+  '@redis/json@1.0.7(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+    optional: true
+
+  '@redis/search@1.2.0(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+    optional: true
+
+  '@redis/time-series@1.1.0(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+    optional: true
 
   '@rollup/rollup-android-arm-eabi@4.24.0':
     optional: true
@@ -2901,6 +2980,9 @@ snapshots:
       fsevents: 2.3.3
 
   clone@2.1.2: {}
+
+  cluster-key-slot@1.1.2:
+    optional: true
 
   code-red@1.0.4:
     dependencies:
@@ -3371,6 +3453,9 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  generic-pool@3.9.0:
+    optional: true
+
   get-intrinsic@1.2.4:
     dependencies:
       es-errors: 1.3.0
@@ -3784,6 +3869,16 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  redis@4.7.0:
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.6.0)
+      '@redis/client': 1.6.0
+      '@redis/graph': 1.1.1(@redis/client@1.6.0)
+      '@redis/json': 1.0.7(@redis/client@1.6.0)
+      '@redis/search': 1.2.0(@redis/client@1.6.0)
+      '@redis/time-series': 1.1.0(@redis/client@1.6.0)
+    optional: true
 
   resolve-from@4.0.0: {}
 
@@ -4205,6 +4300,9 @@ snapshots:
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
+
+  yallist@4.0.0:
+    optional: true
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
- adds support for storing cache data in redis, configurable with `API_REDIS_URL` env (`redis://localhost:6379`)
- adds ability to spawn multiple cross-communicating cobalt processes using `node:cluster`, configured with `API_INSTANCE_COUNT` env
    - requires `API_REDIS_URL` to be configured
    - ratelimit and stream cache exclusively stored in redis
    - istream cache stored locally on each instance, istreams are bound to specific instance that is serving the stream
    - main instance fetches cookies/api keys, distributes them amongst newly spawned processes
    - works on linux, node >= 23.1.0
 