### PR TITLE
rename twitter to twitter/x

### DIFF
--- a/api/src/processing/service-config.js
+++ b/api/src/processing/service-config.js
@@ -131,7 +131,7 @@ export const services = {
         patterns: [":channel/clip/:clip"],
         tld: "tv",
     },
-    twitter: {
+    "twitter/x": {
         patterns: [
             ":user/status/:id",
             ":user/status/:id/video/:index",

--- a/api/src/processing/services/twitter.js
+++ b/api/src/processing/services/twitter.js
@@ -215,7 +215,7 @@ export default async function({ id, index, toGif, dispatcher, alwaysProxy }) {
 
                 if (needsFixing(content) || shouldRenderGif) {
                     url = createStream({
-                        service: "twitter",
+                        service: "twitter/x",
                         type: shouldRenderGif ? "gif" : "remux",
                         url,
                         filename: videoFilename,

--- a/web/src/routes/about/community/+page.svelte
+++ b/web/src/routes/about/community/+page.svelte
@@ -33,7 +33,7 @@
                 externalLink={contacts.discord}
             />
             <AboutSupport
-                platform="twitter"
+                platform="twitter/x"
                 externalLink={contacts.twitter}
             />
             <AboutSupport

--- a/web/src/routes/settings/video/+page.svelte
+++ b/web/src/routes/settings/video/+page.svelte
@@ -69,7 +69,7 @@
     />
 </SettingsCategory>
 
-<SettingsCategory sectionId="twitter" title={$t("settings.video.twitter.gif")}>
+<SettingsCategory sectionId="twitter/x" title={$t("settings.video.twitter.gif")}>
     <SettingsToggle
         settingContext="save"
         settingId="twitterGif"


### PR DESCRIPTION
Attempt 2 to rename "twitter" to "twitter/x" in list of supported services

If I am missing any files that I need to rename, please comment. I was going to edit [service-allias.js](https://github.com/wukko/cobalt/blob/main/api/src/processing/service-alias.js)