### PR TITLE
Fix exposed port in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,5 @@ COPY --from=build --chown=node:node /app/.git /app/.git
 
 USER node
 
-EXPOSE 9000
+EXPOSE ${API_PORT}
 CMD [ "node", "src/cobalt" ]


### PR DESCRIPTION
## WHY
Even if you change the default port for your app by env, Docker still exposes hardcoded port 9000.

## WHAT
This pull request includes a small change to the `Dockerfile`. The change modifies the `EXPOSE` instruction to use an environment variable instead of a hardcoded port number.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L25-R25): Changed `EXPOSE 9000` to `EXPOSE ${API_PORT}` to allow for dynamic port configuration.