### PR TITLE
api/facebook: handle URLs with query parameters in share links

### DIFF
--- a/api/src/processing/services/facebook.js
+++ b/api/src/processing/services/facebook.js
@@ -29,6 +29,12 @@ export default async function({ id, shareType, shortLink }) {
     if (shareType) url = `https://web.facebook.com/share/${shareType}/${id}`;
     if (shortLink) url = await resolveUrl(`https://fb.watch/${shortLink}`);
 
+    // Handle URLs with query parameters like ?mibextid
+    if (url.includes('?')) {
+        const urlObj = new URL(url);
+        url = urlObj.origin + urlObj.pathname;
+    }
+
     const html = await fetch(url, { headers })
         .then(r => r.text())
         .catch(() => false);


### PR DESCRIPTION
This pull request is related to the issue #917 

This pull request includes a change to the `api/src/processing/services/facebook.js` file to handle URLs with query parameters more effectively. The most important change is the addition of a block that processes URLs to remove query parameters, ensuring the URL only includes the origin and pathname.

Enhancements to URL handling:

* [`api/src/processing/services/facebook.js`](diffhunk://#diff-e48e55647a3551a441c11add71a5bcae91fbc97f0d2cd1ea4a82f326931c91d8R32-R37): Added logic to strip query parameters from URLs by creating a `URL` object and reconstructing the URL without the query string.