### PR TITLE
api/twitter: got rate limit try with cookies

### DIFF
--- a/api/src/processing/services/twitter.js
+++ b/api/src/processing/services/twitter.js
@@ -115,6 +115,11 @@ export default async function({ id, index, toGif, dispatcher, alwaysProxy }) {
         tweet = await requestTweet(dispatcher, id, guestToken)
     }
 
+    // if the tweet reached the rate limit, we need to retry with the cookie
+    if ([404].includes(tweet.status))  {
+        tweet = await requestTweet(dispatcher, id, guestToken, cookie);
+    }
+
     tweet = await tweet.json();
 
     let tweetTypename = tweet?.data?.tweetResult?.result?.__typename;


### PR DESCRIPTION
x.com has a policy with public posts. sometimes a rate limit is reached. therefore when that limit is reached you should be able to check with the cookie since it has no limits.