### PR TITLE
api/match-action: pass audio bitrate when creating tiktok stream

### DIFF
--- a/api/src/processing/match-action.js
+++ b/api/src/processing/match-action.js
@@ -102,6 +102,7 @@ export default function({ r, host, audioFormat, isAudioOnly, isAudioMuted, disab
                             filename: `${r.audioFilename}.${audioFormat}`,
                             isAudioOnly: true,
                             audioFormat,
+                            audioBitrate
                         })
                     }
                     break;


### PR DESCRIPTION
fixes #996