### PR TITLE
api/pinterest: fix video parsing (#1148)

### DIFF
--- a/api/src/processing/services/pinterest.js
+++ b/api/src/processing/services/pinterest.js
@@ -23,7 +23,7 @@ export default async function(o) {
 
     const videoLink = [...html.matchAll(videoRegex)]
                     .map(([, link]) => link)
-                    .find(a => a.endsWith('.mp4') && a.includes('720p'));
+                    .find(a => a.endsWith('.mp4'));
 
     if (videoLink) return {
         urls: videoLink,


### PR DESCRIPTION
This PR fixes certain Pinterest videos from returning the user's avatar instead of the video.
https://github.com/imputnet/cobalt/blob/440d039e2cafa12051e7e6c1912a1673ed1eb533/api/src/processing/services/pinterest.js#L26
This section was failing to get the video, as not all Pinterest videos have `720p` in the URL, which failed to parse the video. It would then try to parse for images, hence returning the person who uploaded's avatar.

This is a fix for #1148.