### PR TITLE
api/service-config: add tiktok lite url pattern

### DIFF
--- a/api/src/processing/service-config.js
+++ b/api/src/processing/service-config.js
@@ -136,7 +136,7 @@ export const services = {
     tiktok: {
         patterns: [
             ":user/video/:postId",
-            "i18n/share/video/:postId/",
+            "i18n/share/video/:postId",
             ":shortLink",
             "t/:shortLink",
             ":user/photo/:postId",

--- a/api/src/processing/service-config.js
+++ b/api/src/processing/service-config.js
@@ -136,12 +136,13 @@ export const services = {
     tiktok: {
         patterns: [
             ":user/video/:postId",
+            "i18n/share/video/:postId/",
             ":shortLink",
             "t/:shortLink",
             ":user/photo/:postId",
             "v/:postId.html"
         ],
-        subdomains: ["vt", "vm", "m"],
+        subdomains: ["vt", "vm", "m", "t"],
     },
     tumblr: {
         patterns: [

--- a/api/src/processing/services/tiktok.js
+++ b/api/src/processing/services/tiktok.js
@@ -1,6 +1,6 @@
 import Cookie from "../cookie/cookie.js";
 
-import { extract } from "../url.js";
+import { extract, normalizeURL } from "../url.js";
 import { genericUserAgent } from "../../config.js";
 import { updateCookie } from "../cookie/manager.js";
 import { createStream } from "../../stream/manage.js";
@@ -23,8 +23,8 @@ export default async function(obj) {
 
         if (html.startsWith('<a href="https://')) {
             const extractedURL = html.split('<a href="')[1].split('?')[0];
-            const { patternMatch } = extract(extractedURL);
-            postId = patternMatch.postId;
+            const { patternMatch } = extract(normalizeURL(extractedURL));
+            postId = patternMatch?.postId;
         }
     }
     if (!postId) return { error: "fetch.short_link" };


### PR DESCRIPTION
links copied from tiktok lite use a different structure.
```bash
curl https://vm.tiktok.com/ZSrRvKqDW/
<a href="https://t.tiktok.com/i18n/share/video/7455415590421859617/?...">Moved Permanently</a>.
```

* [`api/src/processing/service-config.js`](diffhunk://#diff-e46dbb2452195cabae3b56ac712455a8c21a68c6e4f44f8c099490922eeb69a3R139-R145): added a new pattern "i18n/share/video/:postId/" 
* [`api/src/processing/service-config.js`](diffhunk://#diff-e46dbb2452195cabae3b56ac712455a8c21a68c6e4f44f8c099490922eeb69a3R139-R145): included "t" as an additional subdomain for tiktok