### PR TITLE
api/core: use `EnvHttpProxyAgent` for proxy requests

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -36,7 +36,7 @@
         "ipaddr.js": "2.2.0",
         "nanoid": "^5.0.9",
         "set-cookie-parser": "2.6.0",
-        "undici": "^5.19.1",
+        "undici": "^7.5.0",
         "url-pattern": "1.0.3",
         "youtubei.js": "^13.3.0",
         "zod": "^3.23.8"

--- a/api/src/core/api.js
+++ b/api/src/core/api.js
@@ -1,7 +1,7 @@
 import cors from "cors";
 import http from "node:http";
 import rateLimit from "express-rate-limit";
-import { setGlobalDispatcher, ProxyAgent } from "undici";
+import { setGlobalDispatcher, EnvHttpProxyAgent } from "undici";
 import { getCommit, getBranch, getRemote, getVersion } from "@imput/version-info";
 
 import jwt from "../security/jwt.js";
@@ -346,7 +346,7 @@ export const runAPI = async (express, app, __dirname, isPrimary = true) => {
             throw new Error('Freebind is not available when external proxy is enabled')
         }
 
-        setGlobalDispatcher(new ProxyAgent(env.externalProxy))
+        setGlobalDispatcher(new EnvHttpProxyAgent(env.externalProxy))
     }
 
     http.createServer(app).listen({

--- a/api/src/util/test.js
+++ b/api/src/util/test.js
@@ -4,7 +4,7 @@ import { env } from "../config.js";
 import { runTest } from "../misc/run-test.js";
 import { loadJSON } from "../misc/load-from-fs.js";
 import { Red, Bright } from "../misc/console-text.js";
-import { setGlobalDispatcher, ProxyAgent } from "undici";
+import { setGlobalDispatcher, EnvHttpProxyAgent } from "undici";
 import { randomizeCiphers } from "../misc/randomize-ciphers.js";
 
 import { services } from "../processing/service-config.js";
@@ -70,7 +70,7 @@ const printHeader = (service, padLen) => {
 }
 
 if (env.externalProxy) {
-    setGlobalDispatcher(new ProxyAgent(env.externalProxy));
+    setGlobalDispatcher(new EnvHttpProxyAgent(env.externalProxy));
 }
 
 env.streamLifespan = 10000;

--- a/docs/run-an-instance.md
+++ b/docs/run-an-instance.md
@@ -61,7 +61,8 @@ sudo service nscd start
 | `API_LISTEN_ADDRESS`  | `0.0.0.0` | `127.0.0.1`             | changes address from which api server is accessible. **if you are using docker, you usually don't need to configure this.** |
 | `API_URL`             | ➖        | `https://api.cobalt.tools/` | changes url from which api server is accessible. <br> ***REQUIRED TO RUN THE API***. |
 | `API_NAME`            | `unknown` | `ams-1`                 | api server name that is shown in `/api/serverInfo`. |
-| `API_EXTERNAL_PROXY`  | ➖        | `http://user:password@127.0.0.1:8080`| url of the proxy that will be passed to [`ProxyAgent`](https://undici.nodejs.org/#/docs/api/ProxyAgent) and used for all external requests. HTTP(S) only. |
+| `API_EXTERNAL_PROXY`  | ➖        | `http://user:password@127.0.0.1:8080`| url of the proxy that will be passed to [`EnvHttpProxyAgent`](https://undici.nodejs.org/#/docs/api/EnvHttpProxyAgent) and used for all external requests. HTTP(S) only. |
+| `NO_PROXY`            | ➖       | `127.0.0.1`              | comma separated list of IPs that will not be proxied. |
 | `CORS_WILDCARD`       | `1`       | `0`                     | toggles cross-origin resource sharing. <br> `0`: disabled. `1`: enabled. |
 | `CORS_URL`            | not used  | `https://cobalt.tools`  | cross-origin resource sharing url. api will be available only from this url if `CORS_WILDCARD` is set to `0`. |
 | `COOKIE_PATH`         | not used  | `/cookies.json`         | path for cookie file relative to main folder. |


### PR DESCRIPTION
This swaps `ProxyAgent` usage to `EnvHttpProxyAgent`. This allows the usage of `NO_PROXY`. This is useful for when using a proxy and a session server locally. The proxy would try to proxy the local IP, which fails of course. Use `EnvHttpProxyAgent` let's us use `NO_PROXY` so we can exclude local addresses from being proxied.