### PR TITLE
api/service-patterns: increase xiaohongshu shareId max length

### DIFF
--- a/api/src/processing/service-patterns.js
+++ b/api/src/processing/service-patterns.js
@@ -78,5 +78,5 @@ export const testers = {
 
     "xiaohongshu": pattern =>
         pattern.id?.length <= 24 && pattern.token?.length <= 64
-        || pattern.shareId?.length <= 12,
+        || pattern.shareId?.length <= 24,
 }


### PR DESCRIPTION
closes #1229 

ids in new share links are longer than 12 characters, i assume that they'll keep growing, so why not bump the limit to 24 chars :3