### PR TITLE
web: proper focus ring

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -282,7 +282,7 @@ a:focus-visible {
     background-color: var(--button-elevated-press);
 }
 
-.button.elevated:not(:focus-visible) {
+.button.elevated {
     box-shadow: none;
 }
 

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -14,7 +14,8 @@
     --purple: #5857d4;
     --orange: #f19a38;
 
-    --focus-ring: 0 0 0 2px var(--blue) inset;
+    --focus-ring: solid 2px var(--blue);
+    --focus-ring-offset: -2px;
 
     --button: #f4f4f4;
     --button-hover: #ededed;
@@ -240,13 +241,14 @@ button, .button {
 }
 
 :focus-visible {
-    box-shadow: var(--focus-ring) !important;
     outline: none;
-    z-index: 1;
 }
 
-[data-focus-ring-hidden]:focus-visible {
-    box-shadow: none !important;
+button:focus-visible,
+a:focus-visible {
+    outline: var(--focus-ring);
+    outline-offset: var(--focus-ring-offset);
+    z-index: 1;
 }
 
 .button.elevated {

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -245,7 +245,8 @@ button, .button {
 }
 
 button:focus-visible,
-a:focus-visible {
+a:focus-visible,
+select:focus-visible {
     outline: var(--focus-ring);
     outline-offset: var(--focus-ring-offset);
 }
@@ -301,7 +302,7 @@ button[disabled] {
 /* important is used because active class is toggled by state */
 /* and added to the end of the list, taking priority */
 .active:focus-visible {
-    color: var(--sidebar-highlight) !important;
+    color: var(--white);
     background-color: var(--blue) !important;
 }
 

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -248,7 +248,11 @@ button:focus-visible,
 a:focus-visible {
     outline: var(--focus-ring);
     outline-offset: var(--focus-ring-offset);
-    z-index: 1;
+}
+
+a:not(.sidebar-tab):not(.subnav-tab):focus-visible {
+    outline-offset: 3px;
+    border-radius: 2px;
 }
 
 .button.elevated {

--- a/web/src/components/buttons/Switcher.svelte
+++ b/web/src/components/buttons/Switcher.svelte
@@ -76,10 +76,7 @@
         width: 100%;
         /* [base button height] - ([switcher padding] * [padding factor to accommodate for]) */
         height: calc(40px - var(--switcher-padding) * 2);
-        border-radius: calc(var(--border-radius) - var(--switcher-padding));;
-    }
-
-    .switcher.big {
+        border-radius: calc(var(--border-radius) - var(--switcher-padding));
         box-shadow: none;
     }
 

--- a/web/src/components/buttons/Switcher.svelte
+++ b/web/src/components/buttons/Switcher.svelte
@@ -79,7 +79,7 @@
         border-radius: calc(var(--border-radius) - var(--switcher-padding));;
     }
 
-    .switcher.big :global(.button:not(:focus-visible)) {
+    .switcher.big {
         box-shadow: none;
     }
 

--- a/web/src/components/changelog/ChangelogEntry.svelte
+++ b/web/src/components/changelog/ChangelogEntry.svelte
@@ -39,7 +39,6 @@
             <div
                 class="changelog-version"
                 data-first-focus
-                data-focus-ring-hidden
                 tabindex="-1"
             >
                 {version}

--- a/web/src/components/dialog/PickerDialog.svelte
+++ b/web/src/components/dialog/PickerDialog.svelte
@@ -106,10 +106,6 @@
         padding: 0;
     }
 
-    .popup-title:focus-visible {
-        box-shadow: none !important;
-    }
-
     .picker-body {
         overflow-y: scroll;
         display: grid;

--- a/web/src/components/dialog/PickerItem.svelte
+++ b/web/src/components/dialog/PickerItem.svelte
@@ -72,7 +72,8 @@
         width: 100%;
         height: 100%;
         position: absolute;
-        box-shadow: var(--focus-ring);
+        outline: var(--focus-ring);
+        outline-offset: var(--focus-ring-offset);
         border-radius: inherit;
     }
 

--- a/web/src/components/dialog/SavingDialog.svelte
+++ b/web/src/components/dialog/SavingDialog.svelte
@@ -148,10 +148,6 @@
         gap: var(--padding);
     }
 
-    .dialog-inner-container:focus-visible {
-        box-shadow: none!important;
-    }
-
     .dialog-inner-container {
         overflow-y: scroll;
         gap: 8px;
@@ -189,10 +185,6 @@
     .popup-title {
         color: var(--secondary);
         font-size: 19px;
-    }
-
-    .popup-title:focus-visible {
-        box-shadow: none !important;
     }
 
     .action-buttons {

--- a/web/src/components/dialog/SmallDialog.svelte
+++ b/web/src/components/dialog/SmallDialog.svelte
@@ -129,11 +129,6 @@
         -webkit-user-select: text;
     }
 
-    .body-text:focus-visible,
-    .popup-title:focus-visible {
-        box-shadow: none !important;
-    }
-
     .popup-subtext {
         opacity: 0.7;
         padding: 0;

--- a/web/src/components/donate/DonateBanner.svelte
+++ b/web/src/components/donate/DonateBanner.svelte
@@ -18,7 +18,6 @@
                 class="redaction"
                 tabindex="-1"
                 data-first-focus
-                data-focus-ring-hidden
             >
                 {$t("donate.banner.title")}
             </div>

--- a/web/src/components/donate/DonateCardContainer.svelte
+++ b/web/src/components/donate/DonateCardContainer.svelte
@@ -43,7 +43,7 @@
         letter-spacing: -0.3px;
     }
 
-    :global(.donate-card button:not(:focus-visible)) {
+    :global(.donate-card button) {
         box-shadow: none;
     }
 
@@ -62,8 +62,8 @@
         cursor: default;
     }
 
-    :global(.donate-card button.selected:not(:focus-visible)) {
-        box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.1) inset !important;
+    :global(.donate-card button.selected) {
+        box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.1) inset;
     }
 
     :global(.donate-card-subtitle) {

--- a/web/src/components/donate/DonateOptionsCard.svelte
+++ b/web/src/components/donate/DonateOptionsCard.svelte
@@ -136,12 +136,7 @@
         </button>
     </div>
 
-    <div
-        id="donation-options-container"
-        class:mask-both={!device.is.mobile && showLeftScroll && showRightScroll}
-        class:mask-left={!device.is.mobile && showLeftScroll && !showRightScroll}
-        class:mask-right={!device.is.mobile && showRightScroll && !showLeftScroll}
-    >
+    <div id="donation-options-container">
         {#if !device.is.mobile}
             <div id="donation-options-scroll" aria-hidden="true">
                 <button
@@ -168,6 +163,9 @@
         <div
             id="donation-options"
             bind:this={donateList}
+            class:mask-both={!device.is.mobile && showLeftScroll && showRightScroll}
+            class:mask-left={!device.is.mobile && showLeftScroll && !showRightScroll}
+            class:mask-right={!device.is.mobile && showRightScroll && !showLeftScroll}
             on:wheel={() => {
                 const currentPos = donateList.scrollLeft;
                 const maxPos = donateList.scrollWidth - donateList.getBoundingClientRect().width - 5;
@@ -359,6 +357,53 @@
         flex-direction: column;
         gap: calc(var(--donate-card-main-padding) / 2);
         position: relative;
+
+        &:hover {
+            & > #donation-options-scroll {
+                opacity: 1;
+            }
+
+            & > #donation-options {
+                &.mask-both {
+                    mask-image: linear-gradient(
+                        90deg,
+                        rgba(0, 0, 0, 0) 0%,
+                        rgba(0, 0, 0, 1) 20%,
+                        rgba(0, 0, 0, 1) 50%,
+                        rgba(0, 0, 0, 1) 80%,
+                        rgba(0, 0, 0, 0) 100%
+                    );
+                }
+
+                &.mask-left {
+                    mask-image: linear-gradient(
+                        90deg,
+                        rgba(0, 0, 0, 0) 0%,
+                        rgba(0, 0, 0, 1) 20%,
+                        rgba(0, 0, 0, 1) 50%,
+                        rgba(0, 0, 0, 1) 97%,
+                        rgba(0, 0, 0, 0) 100%
+                    );
+                }
+
+                &.mask-right {
+                    mask-image: linear-gradient(
+                        90deg,
+                        rgba(0, 0, 0, 0) 0%,
+                        rgba(0, 0, 0, 1) 3%,
+                        rgba(0, 0, 0, 1) 50%,
+                        rgba(0, 0, 0, 1) 80%,
+                        rgba(0, 0, 0, 0) 100%
+                    );
+                }
+            }
+        }
+
+        &:not(:hover) {
+            & > .scroll-button {
+                visibility: hidden;
+            }
+        }
     }
 
     #donation-options-scroll {
@@ -382,49 +427,10 @@
         padding: 0 16px;
         background-color: transparent;
         height: 100%;
-        transition: opacity 0.2s;
-    }
 
-    #donation-options-container:hover #donation-options-scroll {
-        opacity: 1;
-    }
-
-    .scroll-button.hidden {
-        opacity: 0;
-        visibility: hidden;
-    }
-
-    #donation-options-container.mask-both:hover #donation-options {
-        mask-image: linear-gradient(
-            90deg,
-            rgba(0, 0, 0, 0) 0%,
-            rgba(0, 0, 0, 1) 20%,
-            rgba(0, 0, 0, 1) 50%,
-            rgba(0, 0, 0, 1) 80%,
-            rgba(0, 0, 0, 0) 100%
-        );
-    }
-
-    #donation-options-container.mask-left:hover #donation-options {
-        mask-image: linear-gradient(
-            90deg,
-            rgba(0, 0, 0, 0) 0%,
-            rgba(0, 0, 0, 1) 20%,
-            rgba(0, 0, 0, 1) 50%,
-            rgba(0, 0, 0, 1) 97%,
-            rgba(0, 0, 0, 0) 100%
-        );
-    }
-
-    #donation-options-container.mask-right:hover #donation-options {
-        mask-image: linear-gradient(
-            90deg,
-            rgba(0, 0, 0, 0) 0%,
-            rgba(0, 0, 0, 1) 3%,
-            rgba(0, 0, 0, 1) 50%,
-            rgba(0, 0, 0, 1) 80%,
-            rgba(0, 0, 0, 0) 100%
-        );
+        &.hidden {
+            visibility: hidden;
+        }
     }
 
     @media screen and (max-width: 550px) {

--- a/web/src/components/donate/DonateOptionsCard.svelte
+++ b/web/src/components/donate/DonateOptionsCard.svelte
@@ -333,10 +333,6 @@
         opacity: 0.5;
     }
 
-    #donation-custom-input:focus-visible {
-        box-shadow: unset !important;
-    }
-
     #input-container.focused {
         box-shadow: 0 0 0 2px var(--white) inset;
     }

--- a/web/src/components/donate/DonateShareCard.svelte
+++ b/web/src/components/donate/DonateShareCard.svelte
@@ -162,12 +162,9 @@
         box-shadow: 0 0 0 2px rgba(255, 255, 255, var(--donate-border-opacity));
     }
 
-    #share-qr:focus-visible {
-        box-shadow: none !important;
-    }
-
     #share-qr:focus-visible :global(svg) {
-        box-shadow: 0 0 0 2px var(--blue);
+        outline: var(--focus-ring);
+        outline-offset: var(--focus-ring-offset);
     }
 
     #action-buttons {

--- a/web/src/components/misc/FileReceiver.svelte
+++ b/web/src/components/misc/FileReceiver.svelte
@@ -81,7 +81,7 @@
         transition: box-shadow 0.2s;
     }
 
-    .open-file-button:not(:focus-visible) {
+    .open-file-button {
         box-shadow: none;
     }
 
@@ -130,6 +130,10 @@
 
     .open-file-button:focus-visible .dashed-stroke :global(svg rect) {
         stroke: var(--blue);
+    }
+
+    .open-file-button:focus-visible {
+        outline: none;
     }
 
     .open-file-container :global(.meowbalt) {

--- a/web/src/components/misc/Placeholder.svelte
+++ b/web/src/components/misc/Placeholder.svelte
@@ -6,7 +6,7 @@
 
 <div id="placeholder-container" class="center-column-container">
     <Meowbalt emotion="smile" />
-    <div tabindex="-1" data-first-focus data-focus-ring-hidden>
+    <div tabindex="-1" data-first-focus>
         {`${pageName} page is not ready yet!`}
     </div>
 </div>

--- a/web/src/components/queue/ProcessingStatus.svelte
+++ b/web/src/components/queue/ProcessingStatus.svelte
@@ -51,7 +51,8 @@
     }
 
     #processing-status:focus-visible {
-        box-shadow: 0 0 0 2px var(--white) !important;
+        outline: 2px solid var(--secondary);
+        outline-offset: 2px;
     }
 
     #processing-status:active {
@@ -59,7 +60,7 @@
     }
 
     #processing-status.completed {
-        box-shadow: var(--focus-ring);
+        box-shadow: 0 0 0 2px var(--blue) inset;
     }
 
     :global([data-theme="light"]) #processing-status.completed {

--- a/web/src/components/queue/ProcessingStatus.svelte
+++ b/web/src/components/queue/ProcessingStatus.svelte
@@ -40,7 +40,6 @@
         pointer-events: all;
         padding: 7px;
         border-radius: 30px;
-        box-shadow: var(--button-box-shadow);
 
         filter: drop-shadow(0 0 3px var(--button-elevated-hover));
 

--- a/web/src/components/save/Omnibox.svelte
+++ b/web/src/components/save/Omnibox.svelte
@@ -305,10 +305,6 @@
         padding-right: calc(var(--input-padding) + 28px);
     }
 
-    #link-area:focus-visible {
-        box-shadow: unset !important;
-    }
-
     #link-area::placeholder {
         color: var(--gray);
         /* fix for firefox */

--- a/web/src/components/save/SupportedServices.svelte
+++ b/web/src/components/save/SupportedServices.svelte
@@ -98,7 +98,7 @@
             box-shadow 0.1s;
     }
 
-    #services-button:not(:focus-visible):not(:active) {
+    #services-button:not(:active) {
         box-shadow: none;
     }
 

--- a/web/src/components/save/SupportedServices.svelte
+++ b/web/src/components/save/SupportedServices.svelte
@@ -52,7 +52,6 @@
             id="services-container"
             bind:this={servicesContainer}
             tabindex="-1"
-            data-focus-ring-hidden
         >
             {#if loaded}
                 {#each services as service}

--- a/web/src/components/save/buttons/DownloadButton.svelte
+++ b/web/src/components/save/buttons/DownloadButton.svelte
@@ -102,10 +102,6 @@
         padding: 0 12px 0 15px;
     }
 
-    #download-button:focus-visible {
-        box-shadow: var(--focus-ring);
-    }
-
     #download-state {
         font-size: 24px;
         font-family: "Noto Sans Mono Variable", "Noto Sans Mono",

--- a/web/src/components/settings/SettingsInput.svelte
+++ b/web/src/components/settings/SettingsInput.svelte
@@ -223,10 +223,6 @@
         white-space: nowrap;
     }
 
-    .input-box:focus-visible {
-        box-shadow: unset !important;
-    }
-
     #input-container.focused {
         box-shadow: 0 0 0 2px var(--secondary) inset;
     }

--- a/web/src/components/subnav/PageNav.svelte
+++ b/web/src/components/subnav/PageNav.svelte
@@ -63,7 +63,6 @@
                     aria-level="1"
                     tabindex="-1"
                     data-first-focus
-                    data-focus-ring-hidden
                 >
                     {#if !isHome}
                         {$t(`${pageName}.page.${currentPageTitle}`)}
@@ -110,7 +109,6 @@
             class:wide={wideContent}
             tabindex="-1"
             data-first-focus
-            data-focus-ring-hidden
         >
             <slot name="content"></slot>
         </main>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -17,7 +17,6 @@
         id="cobalt-save"
         tabindex="-1"
         data-first-focus
-        data-focus-ring-hidden
     >
         <Meowbalt emotion="smile" />
         <Omnibox />

--- a/web/src/routes/remux/+page.svelte
+++ b/web/src/routes/remux/+page.svelte
@@ -41,7 +41,6 @@
         id="remux-open"
         tabindex="-1"
         data-first-focus
-        data-focus-ring-hidden
     >
         <div id="remux-receiver">
             <FileReceiver

--- a/web/src/routes/updates/+page.svelte
+++ b/web/src/routes/updates/+page.svelte
@@ -184,7 +184,7 @@
         stroke-width: 1.6px;
     }
 
-    .button-wrapper-desktop button:not(:focus-visible) {
+    .button-wrapper-desktop button {
         box-shadow: none;
     }
 

--- a/web/src/routes/updates/+page.svelte
+++ b/web/src/routes/updates/+page.svelte
@@ -90,7 +90,7 @@
 
 <svelte:window on:keydown={handleKeydown} />
 
-<div class="news" tabindex="-1" data-focus-ring-hidden on:wheel={handleScroll}>
+<div class="news" tabindex="-1" on:wheel={handleScroll}>
     {#if changelog}
         <div id="left-button" class="button-wrapper-desktop">
             {#if prev}


### PR DESCRIPTION
- uses outline instead of box-shadow to not conflict with existing box-shadow on many elements
- shows the focus ring only on clickable elements (button & a)
- removes data-focus-ring-hidden & all other related workarounds
- fixes the focus ring of the processing status button and file receiver