### PR TITLE
api/bilibili: support download episode in collection

### DIFF
--- a/api/src/processing/service-config.js
+++ b/api/src/processing/service-config.js
@@ -7,6 +7,7 @@ export const services = {
     bilibili: {
         patterns: [
             "video/:comId",
+            "video/:comId?p=:episode",
             "_shortLink/:comShortLink",
             "_tv/:lang/video/:tvId",
             "_tv/video/:tvId"

--- a/api/src/processing/services/bilibili.js
+++ b/api/src/processing/services/bilibili.js
@@ -17,8 +17,12 @@ function extractBestQuality(dashData) {
     return [ bestVideo, bestAudio ];
 }
 
-async function com_download(id) {
-    let html = await fetch(`https://bilibili.com/video/${id}`, {
+async function com_download(id , episode = 1) {
+    let fetchUrl = `https://bilibili.com/video/${id}`;
+    if (episode > 1) {
+        fetchUrl += `?p=${episode}`
+    }
+    let html = await fetch(fetchUrl, {
         headers: {
             "user-agent": genericUserAgent
         }
@@ -86,14 +90,14 @@ async function tv_download(id) {
     };
 }
 
-export default async function({ comId, tvId, comShortLink }) {
+export default async function ({comId, tvId, comShortLink, episode}) {
     if (comShortLink) {
         const patternMatch = await resolveRedirectingURL(`https://b23.tv/${comShortLink}`);
         comId = patternMatch?.comId;
     }
 
     if (comId) {
-        return com_download(comId);
+        return com_download(comId, episode ? episode : 1);
     } else if (tvId) {
         return tv_download(tvId);
     }

--- a/api/src/processing/url.js
+++ b/api/src/processing/url.js
@@ -159,6 +159,11 @@ function cleanURL(url) {
                 limitQuery('xsec_token');
             }
             break;
+        case "bilibili":
+            if (url.searchParams.get('p')) {
+                limitQuery('p');
+            }
+            break;
     }
 
     if (stripQuery) {


### PR DESCRIPTION
Previously, Cobalt only downloaded the first video in a Bilibili collection.
This PR adds the ability to download different episodes from the collection.