### PR TITLE
Update run-an-instance.md

### DIFF
--- a/docs/run-an-instance.md
+++ b/docs/run-an-instance.md
@@ -41,7 +41,7 @@ requirements:
 - pnpm
 
 1. clone the repo: `git clone https://github.com/imputnet/cobalt`.
-2. go to api/src directory: `cd cobalt/api/src`.
+2. go to api directory: `cd cobalt/api`.
 3. install dependencies: `pnpm install`.
 4. create `.env` file in the same directory.
 5. add needed environment variables to `.env` file. only `API_URL` is required to run cobalt.


### PR DESCRIPTION
Since the `package.json` is found in the `/api` directory, there is no need to go to the `/api/src` directory to run `pnpm start` & `pnpm install`. This also means step 4 holds true now. Before you actually needed to navigate back to the `/api` directory to create the `.env` file