### PR TITLE
api/stream: add Transfer-Encoding header to tunnel responses

### DIFF
--- a/api/src/core/api.js
+++ b/api/src/core/api.js
@@ -276,7 +276,8 @@ export const runAPI = async (express, app, __dirname, isPrimary = true) => {
         methods: ['GET'],
         exposedHeaders: [
             'Estimated-Content-Length',
-            'Content-Disposition'
+            'Content-Disposition',
+            'Transfer-Encoding'
         ],
         ...corsConfig,
     }));

--- a/api/src/stream/types.js
+++ b/api/src/stream/types.js
@@ -156,6 +156,7 @@ const merge = async (streamInfo, res) => {
         res.setHeader('Connection', 'keep-alive');
         res.setHeader('Content-Disposition', contentDisposition(streamInfo.filename));
         res.setHeader('Estimated-Content-Length', await estimateTunnelLength(streamInfo));
+        res.setHeader('Transfer-Encoding', 'chunked');
 
         pipe(muxOutput, res, shutdown);
 
@@ -220,6 +221,7 @@ const remux = async (streamInfo, res) => {
         res.setHeader('Connection', 'keep-alive');
         res.setHeader('Content-Disposition', contentDisposition(streamInfo.filename));
         res.setHeader('Estimated-Content-Length', await estimateTunnelLength(streamInfo));
+        res.setHeader('Transfer-Encoding', 'chunked');
 
         pipe(muxOutput, res, shutdown);
 
@@ -296,6 +298,7 @@ const convertAudio = async (streamInfo, res) => {
                 estimateAudioMultiplier(streamInfo) * 1.1
             )
         );
+        res.setHeader('Transfer-Encoding', 'chunked');
 
         pipe(muxOutput, res, shutdown);
         res.on('finish', shutdown);
@@ -334,6 +337,7 @@ const convertGif = async (streamInfo, res) => {
         res.setHeader('Connection', 'keep-alive');
         res.setHeader('Content-Disposition', contentDisposition(streamInfo.filename));
         res.setHeader('Estimated-Content-Length', await estimateTunnelLength(streamInfo, 60));
+        res.setHeader('Transfer-Encoding', 'chunked');
 
         pipe(muxOutput, res, shutdown);
 


### PR DESCRIPTION
For HTTP/1.1 when the length of the content isn't known, you must send the header `Transfer-Encoding: chunked`, so the client knows that it needs to process the response in parts (chunks). This header is deprecated in HTTP/2, and maybe not neccessary when using a proxy (nginx, haproxy, etc), but neccesary when accesing cobalt directly. https://en.wikipedia.org/wiki/Chunked_transfer_encoding

When the header is not present, downloading files from the tunnel will result is a 0 bytes file, as client will follow the `Content-Length` header, which is set to 0