### PR TITLE
api/stream: refactor and simplify ffmpeg-related code

### DIFF
--- a/api/src/processing/match-action.js
+++ b/api/src/processing/match-action.js
@@ -194,7 +194,7 @@ export default function({
             break;
 
         case "audio":
-            if (audioIgnore.includes(host) || (host === "reddit" && r.typeId === "redirect")) {
+            if (audioIgnore.has(host) || (host === "reddit" && r.typeId === "redirect")) {
                 return createResponse("error", {
                     code: "error.api.service.audio_not_supported"
                 })

--- a/api/src/processing/service-config.js
+++ b/api/src/processing/service-config.js
@@ -1,7 +1,7 @@
 import UrlPattern from "url-pattern";
 
-export const audioIgnore = ["vk", "ok", "loom"];
-export const hlsExceptions = ["dailymotion", "vimeo", "rutube", "bsky", "youtube"];
+export const audioIgnore = new Set(["vk", "ok", "loom"]);
+export const hlsExceptions = new Set(["dailymotion", "vimeo", "rutube", "bsky", "youtube"]);
 
 export const services = {
     bilibili: {

--- a/api/src/stream/ffmpeg.js
+++ b/api/src/stream/ffmpeg.js
@@ -118,6 +118,8 @@ const remux = async (streamInfo, res) => {
             '-c:v', 'copy',
         );
     } else {
+        args.push('-map', '0:v:0');
+        args.push('-map', '0:a:0');
         args.push('-c:v', 'copy');
     }
 

--- a/api/src/stream/ffmpeg.js
+++ b/api/src/stream/ffmpeg.js
@@ -136,7 +136,7 @@ const remux = async (streamInfo, res) => {
         args.push('-movflags', 'faststart+frag_keyframe+empty_moov');
     }
 
-    if (streamInfo.type !== 'mute' && streamInfo.isHLS && hlsExceptions.includes(streamInfo.service)) {
+    if (streamInfo.type !== 'mute' && streamInfo.isHLS && hlsExceptions.has(streamInfo.service)) {
         if (streamInfo.service === 'youtube' && format === 'webm') {
             args.push('-c:a', 'libopus');
         } else {

--- a/api/src/stream/ffmpeg.js
+++ b/api/src/stream/ffmpeg.js
@@ -29,7 +29,7 @@ const convertMetadataToFFmpeg = (metadata) => {
                 args.push('-metadata:s:s:0', `language=${value}`);
                 continue;
             }
-            args.push('-metadata', `${name}=${value.replace(/[\u0000-\u0009]/g, "")}`); // skipcq: JS-0004
+            args.push('-metadata', `${name}=${value.replace(/[\u0000-\u0009]/g, '')}`); // skipcq: JS-0004
         } else {
             throw `${name} metadata tag is not supported.`;
         }
@@ -116,17 +116,14 @@ const remux = async (streamInfo, res) => {
             '-map', '0:v',
             '-map', '1:a',
             '-c:v', 'copy',
-            '-c:a', 'copy'
         );
     } else {
         args.push('-c:v', 'copy');
-
-        if (streamInfo.type === 'mute') {
-            args.push('-an');
-        } else {
-            args.push('-c:a', 'copy');
-        }
     }
+
+    args.push(
+        ...(streamInfo.type === 'mute' ? ['-an'] : ['-c:a', 'copy'])
+    );
 
     if (format === 'mp4') {
         args.push('-movflags', 'faststart+frag_keyframe+empty_moov');
@@ -175,7 +172,7 @@ const convertAudio = async (streamInfo, res) => {
     args.push(
         '-f',
         streamInfo.audioFormat === 'm4a' ? 'ipod' : streamInfo.audioFormat,
-        'pipe:3'
+        'pipe:3',
     );
 
     await render(
@@ -194,7 +191,7 @@ const convertGif = async (streamInfo, res) => {
         'scale=-1:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse',
         '-loop', '0',
 
-        '-f', "gif", 'pipe:3',
+        '-f', 'gif', 'pipe:3',
     ];
 
     await render(

--- a/api/src/stream/proxy.js
+++ b/api/src/stream/proxy.js
@@ -1,0 +1,43 @@
+import { Agent, request } from "undici";
+import { create as contentDisposition } from "content-disposition-header";
+
+import { destroyInternalStream } from "./manage.js";
+import { getHeaders, closeRequest, closeResponse, pipe } from "./shared.js";
+
+const defaultAgent = new Agent();
+
+export default async function (streamInfo, res) {
+    const abortController = new AbortController();
+    const shutdown = () => (
+        closeRequest(abortController),
+        closeResponse(res),
+        destroyInternalStream(streamInfo.urls)
+    );
+
+    try {
+        res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+        res.setHeader('Content-disposition', contentDisposition(streamInfo.filename));
+
+        const { body: stream, headers, statusCode } = await request(streamInfo.urls, {
+            headers: {
+                ...getHeaders(streamInfo.service),
+                Range: streamInfo.range
+            },
+            signal: abortController.signal,
+            maxRedirections: 16,
+            dispatcher: defaultAgent,
+        });
+
+        res.status(statusCode);
+
+        for (const headerName of ['accept-ranges', 'content-type', 'content-length']) {
+            if (headers[headerName]) {
+                res.setHeader(headerName, headers[headerName]);
+            }
+        }
+
+        pipe(stream, res, shutdown);
+    } catch {
+        shutdown();
+    }
+}

--- a/api/src/stream/stream.js
+++ b/api/src/stream/stream.js
@@ -13,8 +13,6 @@ export default async function(res, streamInfo) {
                 return await internalStream(streamInfo.data, res);
 
             case "merge":
-                return await stream.merge(streamInfo, res);
-
             case "remux":
             case "mute":
                 return await stream.remux(streamInfo, res);

--- a/api/src/stream/stream.js
+++ b/api/src/stream/stream.js
@@ -1,4 +1,5 @@
-import stream from "./types.js";
+import proxy from "./proxy.js";
+import ffmpeg from "./ffmpeg.js";
 
 import { closeResponse } from "./shared.js";
 import { internalStream } from "./internal.js";
@@ -7,7 +8,7 @@ export default async function(res, streamInfo) {
     try {
         switch (streamInfo.type) {
             case "proxy":
-                return await stream.proxy(streamInfo, res);
+                return await proxy(streamInfo, res);
 
             case "internal":
                 return await internalStream(streamInfo.data, res);
@@ -15,13 +16,13 @@ export default async function(res, streamInfo) {
             case "merge":
             case "remux":
             case "mute":
-                return await stream.remux(streamInfo, res);
+                return await ffmpeg.remux(streamInfo, res);
 
             case "audio":
-                return await stream.convertAudio(streamInfo, res);
+                return await ffmpeg.convertAudio(streamInfo, res);
 
             case "gif":
-                return await stream.convertGif(streamInfo, res);
+                return await ffmpeg.convertGif(streamInfo, res);
         }
 
         closeResponse(res);


### PR DESCRIPTION
- split types.js into ffmpeg.js and proxy.js
- created render() which handles ffmpeg & piping stuff
- merged remux() and merge() into one function
- simplified and cleaned up arguments
- removed headers since they're handled by internal streams now
- removed outdated arguments