### PR TITLE
feat: newgrounds video & audio support

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -23,6 +23,7 @@ if the desired service isn't supported yet, feel free to create an appropriate i
 | instagram         | ✅            | ✅         | ✅         | ➖         | ➖              |
 | facebook          | ✅            | ❌         | ✅         | ➖         | ➖              |
 | loom              | ✅            | ❌         | ✅         | ✅         | ➖              |
+| newgrounds        | ✅            | ✅         | ✅         | ✅         | ✅              |
 | ok.ru             | ✅            | ❌         | ✅         | ✅         | ✅              |
 | pinterest         | ✅            | ✅         | ✅         | ➖         | ➖              |
 | reddit            | ✅            | ✅         | ✅         | ❌         | ❌              |

--- a/api/src/processing/match-action.js
+++ b/api/src/processing/match-action.js
@@ -180,6 +180,7 @@ export default function({
 
                 case "ok":
                 case "xiaohongshu":
+                case "newgrounds":
                     params = { type: "proxy" };
                     break;
 

--- a/api/src/processing/match.js
+++ b/api/src/processing/match.js
@@ -29,6 +29,7 @@ import loom from "./services/loom.js";
 import facebook from "./services/facebook.js";
 import bluesky from "./services/bluesky.js";
 import xiaohongshu from "./services/xiaohongshu.js";
+import newgrounds from "./services/newgrounds.js";
 
 let freebind;
 
@@ -265,6 +266,17 @@ export default async function({ host, patternMatch, params, authType }) {
                     h265: params.allowH265,
                     isAudioOnly,
                     dispatcher,
+                });
+                break;
+
+            case "newgrounds":
+                r = await newgrounds({
+                    type: patternMatch.type,
+                    method: patternMatch.method,
+                    id: patternMatch.id,
+                    quality: params.videoQuality,
+                    isAudioOnly,
+                    isAudioMuted
                 });
                 break;
 

--- a/api/src/processing/service-config.js
+++ b/api/src/processing/service-config.js
@@ -74,6 +74,9 @@ export const services = {
             "url_shortener/:shortLink"
         ],
     },
+    newgrounds: {
+        patterns: [":type/:method/:id"]
+    },
     reddit: {
         patterns: [
             "comments/:id",

--- a/api/src/processing/service-patterns.js
+++ b/api/src/processing/service-patterns.js
@@ -79,4 +79,9 @@ export const testers = {
     "xiaohongshu": pattern =>
         pattern.id?.length <= 24 && pattern.token?.length <= 64
         || pattern.shareId?.length <= 24,
+
+    "newgrounds": (patternMatch) =>
+        (patternMatch.type == 'portal' && patternMatch.method == 'view')
+        || (patternMatch.type == 'audio' && patternMatch.method == 'listen')
+        && patternMatch.id?.length >= 1,
 }

--- a/api/src/processing/services/newgrounds.js
+++ b/api/src/processing/services/newgrounds.js
@@ -71,19 +71,19 @@ async function getVideo(obj) {
     .then(request => request.text())
     .catch(() => {});
 
-    if (!req) return { error: 'ErrorCouldntFetch' };
+    if (!req) return { error: 'fetch.fail' };
 
     let json;
     try {
         json = JSON.parse(req);
-    } catch { return { error: 'ErrorEmptyDownload' }; }
+    } catch { return { error: 'fetch.empty' }; }
 
     const videoData = getQuality(json.sources, obj.quality);
     if (videoData == null) {
-        return { error: 'ErrorCouldntFetch' };
+        return { error: 'fetch.empty' };
     }
     if (!videoData.type.includes('mp4')) {
-        return { error: 'ErrorCouldntFetch' };
+        return { error: 'fetch.empty' };
     }
 
     let fileMetadata = {
@@ -115,14 +115,14 @@ async function getMusic(obj) {
     .then(request => request.text())
     .catch(() => {});
 
-    if (!req) return { error: 'ErrorCouldntFetch' };
+    if (!req) return { error: 'fetch.fail' };
 
     const titleMatch = req.match(/"name"\s*:\s*"([^"]+)"/);
     const artistMatch = req.match(/"artist"\s*:\s*"([^"]+)"/);
     const urlMatch = req.match(/"filename"\s*:\s*"([^"]+)"/);
 
     if (!titleMatch || !artistMatch || !urlMatch) {
-        return { error: 'ErrorCouldntFetch' };
+        return { error: 'fetch.empty' };
     }
 
     const title = titleMatch[1];
@@ -153,5 +153,5 @@ export default function(obj) {
     if (obj.type == 'audio') {
         return getMusic(obj);
     }
-    return { error: 'ErrorUnsupported' };
+    return { error: 'link.unsupported' };
 }

--- a/api/src/processing/services/newgrounds.js
+++ b/api/src/processing/services/newgrounds.js
@@ -1,0 +1,157 @@
+import { genericUserAgent } from "../../config.js";
+import { cleanString } from "../../misc/utils.js";
+
+const qualities = ["4k", "1440p", "1080p", "720p", "480p", "360p", "240p", "144p"];
+
+const qualityMatch = {
+    2160: "4k",
+    1440: "1440p",
+    1080: "1080p",
+    720: "720p",
+    480: "480p",
+    360: "360p",
+    240: "240p",
+    144: "144p"
+}
+
+function getQuality(sources, requestedQuality) {
+    if (requestedQuality == "max") {
+        for (let quality of qualities) {
+            if (sources[quality]) {
+                return {
+                    src: sources[quality][0].src,
+                    quality: quality,
+                    type: sources[quality][0].type,
+                }
+            }
+        }
+    }
+
+    let videoData = sources[qualityMatch[requestedQuality]];
+    if (videoData) {
+        return {
+            src: videoData[0].src,
+            quality: requestedQuality + "p",
+            type: videoData[0].type,
+        }
+    }
+
+    const qualityIndex = qualities.indexOf(qualityMatch[requestedQuality]);
+    if (qualityIndex !== -1) {
+        for (let i = qualityIndex; i >= 0; i--) {
+            if (sources[qualities[i]]) {
+                return {
+                    src: sources[qualities[i]][0].src,
+                    quality: qualities[i],
+                    type: sources[qualities[i]][0].type,
+                }
+            }
+        }
+        for (let i = qualityIndex + 1; i < qualities.length; i++) {
+            if (sources[qualities[i]]) {
+                return {
+                    src: sources[qualities[i]][0].src,
+                    quality: qualities[i],
+                    type: sources[qualities[i]][0].type,
+                }
+            }
+        }
+    }
+
+    return null;
+}
+
+async function getVideo(obj) {
+    let req = await fetch(`https://www.newgrounds.com/portal/video/${obj.id}`, {
+        headers: {
+            'User-Agent': genericUserAgent,
+            'X-Requested-With': 'XMLHttpRequest',
+        }
+    })
+    .then(request => request.text())
+    .catch(() => {});
+
+    if (!req) return { error: 'ErrorCouldntFetch' };
+
+    let json;
+    try {
+        json = JSON.parse(req);
+    } catch { return { error: 'ErrorEmptyDownload' }; }
+
+    const videoData = getQuality(json.sources, obj.quality);
+    if (videoData == null) {
+        return { error: 'ErrorCouldntFetch' };
+    }
+    if (!videoData.type.includes('mp4')) {
+        return { error: 'ErrorCouldntFetch' };
+    }
+
+    let fileMetadata = {
+        title: cleanString(decodeURIComponent(json.title)),
+        artist: cleanString(decodeURIComponent(json.author)),
+    }
+
+    return {
+        urls: videoData.src,
+        filenameAttributes: {
+            service: "newgrounds",
+            id: obj.id,
+            title: fileMetadata.title,
+            author: fileMetadata.artist,
+            extension: 'mp4',
+            qualityLabel: videoData.quality,
+            resolution: videoData.quality
+        },
+        fileMetadata,
+    }
+}
+
+async function getMusic(obj) {
+    let req = await fetch(`https://www.newgrounds.com/audio/listen/${obj.id}`, {
+        headers: {
+            'User-Agent': genericUserAgent,
+        }
+    })
+    .then(request => request.text())
+    .catch(() => {});
+
+    if (!req) return { error: 'ErrorCouldntFetch' };
+
+    const titleMatch = req.match(/"name"\s*:\s*"([^"]+)"/);
+    const artistMatch = req.match(/"artist"\s*:\s*"([^"]+)"/);
+    const urlMatch = req.match(/"filename"\s*:\s*"([^"]+)"/);
+
+    if (!titleMatch || !artistMatch || !urlMatch) {
+        return { error: 'ErrorCouldntFetch' };
+    }
+
+    const title = titleMatch[1];
+    const artist = artistMatch[1];
+    const url = urlMatch[1].replace(/\\\//g, '/');
+    let fileMetadata = {
+        title: cleanString(decodeURIComponent(title.trim())),
+        artist: cleanString(decodeURIComponent(artist.trim())),
+    }
+
+    return {
+        urls: url,
+        filenameAttributes: {
+            service: "newgrounds",
+            id: obj.id,
+            title: fileMetadata.title,
+            author: fileMetadata.artist,
+        },
+        fileMetadata,
+        isAudioOnly: true
+    }
+}
+
+export default function(obj) {
+    if (obj.type == 'portal') {
+        return getVideo(obj);
+    }
+    if (obj.type == 'audio') {
+        return getMusic(obj);
+    }
+    return { error: 'ErrorUnsupported' };
+}

--- a/api/src/processing/services/newgrounds.js
+++ b/api/src/processing/services/newgrounds.js
@@ -1,5 +1,4 @@
 import { genericUserAgent } from "../../config.js";
-import { cleanString } from "../../misc/utils.js";
 
 const qualities = ["4k", "1440p", "1080p", "720p", "480p", "360p", "240p", "144p"];
 
@@ -87,8 +86,8 @@ async function getVideo(obj) {
     }
 
     let fileMetadata = {
-        title: cleanString(decodeURIComponent(json.title)),
-        artist: cleanString(decodeURIComponent(json.author)),
+        title: decodeURIComponent(json.title),
+        artist: decodeURIComponent(json.author),
     }
 
     return {
@@ -129,8 +128,8 @@ async function getMusic(obj) {
     const artist = artistMatch[1];
     const url = urlMatch[1].replace(/\\\//g, '/');
     let fileMetadata = {
-        title: cleanString(decodeURIComponent(title.trim())),
-        artist: cleanString(decodeURIComponent(artist.trim())),
+        title: decodeURIComponent(title.trim()),
+        artist: decodeURIComponent(artist.trim()),
     }
 
     return {

--- a/api/src/util/tests/newgrounds.json
+++ b/api/src/util/tests/newgrounds.json
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "regular video",
+        "url": "https://www.newgrounds.com/portal/view/938050",
+        "params": {},
+        "expected": {
+            "code": 200,
+            "status": "tunnel"
+        }
+    },
+    {
+        "name": "regular video (audio only)",
+        "url": "https://www.newgrounds.com/portal/view/938050",
+        "params": {
+            "downloadMode": "audio"
+        },
+        "expected": {
+            "code": 200,
+            "status": "tunnel"
+        }
+    },
+    {
+        "name": "regular video (muted)",
+        "url": "https://www.newgrounds.com/portal/view/938050",
+        "params": {
+            "downloadMode": "mute"
+        },
+        "expected": {
+            "code": 200,
+            "status": "tunnel"
+        }
+    },
+    {
+        "name": "regular music",
+        "url": "https://www.newgrounds.com/audio/listen/500476",
+        "params": {},
+        "expected": {
+            "code": 200,
+            "status": "tunnel"
+        }
+    }
+]


### PR DESCRIPTION
copy of #682, but on my personal account because github doesn't allow collabs on organization PRs 

a cleaner version of my previous pull request, no ugly history this time.

adds support for newgrounds video & music.

example links:
* https://www.newgrounds.com/portal/view/938050 - video
* https://www.newgrounds.com/audio/listen/500476 - music

~~videos are returned as the highest quality available. support for picking the resolution could be added easily, since newgrounds stores multiple resolutions.~~

this pull request would close #620 (except for art, but I don't see a reason for it being added here).