### PR TITLE
api/twitch: add support for m. subdomain

### DIFF
--- a/api/src/processing/service-config.js
+++ b/api/src/processing/service-config.js
@@ -165,6 +165,7 @@ export const services = {
     twitch: {
         patterns: [":channel/clip/:clip"],
         tld: "tv",
+        subdomains: ["clips", "www", "m"],
     },
     twitter: {
         patterns: [


### PR DESCRIPTION
This PR adds a simple fix that allows twitch clips with `m.` subdomain to be downloaded.