### PR TITLE
Fix web build when cloned as submodule

### DIFF
--- a/web/src/routes/version.json/+server.ts
+++ b/web/src/routes/version.json/+server.ts
@@ -1,5 +1,28 @@
 import { json } from "@sveltejs/kit";
-import { getCommit, getBranch, getRemote, getVersion } from "@imput/version-info";
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
+
+async function getCommit(): Promise<string> {
+    const { stdout } = await execAsync("git rev-parse HEAD");
+    return stdout.trim();
+}
+
+async function getBranch(): Promise<string> {
+    const { stdout } = await execAsync("git rev-parse --abbrev-ref HEAD");
+    return stdout.trim();
+}
+
+async function getRemote(): Promise<string> {
+    const { stdout } = await execAsync("git config --get remote.origin.url");
+    return stdout.trim();
+}
+
+async function getVersion(): Promise<string> {
+    const { stdout } = await execAsync("git describe --tags --always");
+    return stdout.trim();
+}
 
 export async function GET() {
     return json({
@@ -11,3 +34,5 @@ export async function GET() {
 }
 
 export const prerender = true;
+
+


### PR DESCRIPTION
Ran into an issue building the frontend because of the `get` functions of the `imput/version-info` package if cobalt was cloned as a git submodule, so I decided to implement them instead.

This change relies on the pure execution of `git` to make it work.

Having `git` installed is required for it to work.

I am happy to work on it if it's not up to the standards!