### PR TITLE
api/vimeo: add support for specifying access tokens

### DIFF
--- a/api/src/processing/cookie/manager.js
+++ b/api/src/processing/cookie/manager.js
@@ -13,6 +13,7 @@ const VALID_SERVICES = new Set([
     'reddit',
     'twitter',
     'youtube',
+    'vimeo_bearer',
 ]);
 
 const invalidCookies = {};

--- a/api/src/processing/services/vimeo.js
+++ b/api/src/processing/services/vimeo.js
@@ -1,6 +1,7 @@
 import HLS from "hls-parser";
 import { env } from "../../config.js";
 import { merge } from '../../misc/utils.js';
+import { getCookie } from "../cookie/manager.js";
 
 const resolutionMatch = {
     "3840": 2160,
@@ -25,7 +26,8 @@ const genericHeaders = {
 let bearer = '';
 
 const getBearer = async (refresh = false) => {
-    if (bearer && !refresh) return bearer;
+    const cookie = getCookie('vimeo_bearer')?.values?.()?.access_token;
+    if ((bearer || cookie) && !refresh) return bearer || cookie;
 
     const oauthResponse = await fetch(
         'https://api.vimeo.com/oauth/authorize/client',

--- a/docs/examples/cookies.example.json
+++ b/docs/examples/cookies.example.json
@@ -13,5 +13,8 @@
     ],
     "youtube": [
         "cookie=<replace_this>; b=<replace_this>"
+    ],
+    "vimeo": [
+        "access_token=<replace_this>"
     ]
 }


### PR DESCRIPTION
the android client now also needs a valid device_identifier, but already generated access_tokens work fine
you can also get them from a rooted device by mitm'ing the device while starting vimeo for the first time or going into its data directory and searching for the token in shared_prefs/

i've been using this on cobalt.meowing.de for a month or so and it's been working fine - never had to replace the token