### PR TITLE
bilibili: use another user agent

### DIFF
--- a/api/src/processing/services/bilibili.js
+++ b/api/src/processing/services/bilibili.js
@@ -1,4 +1,4 @@
-import { genericUserAgent, env } from "../../config.js";
+import { env } from "../../config.js";
 import { resolveRedirectingURL } from "../url.js";
 
 // TO-DO: higher quality downloads (currently requires an account)
@@ -26,7 +26,7 @@ async function com_download(id, partId) {
 
     const html = await fetch(url, {
         headers: {
-            "user-agent": genericUserAgent
+            "user-agent": "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)",
         }
     })
     .then(r => r.text())


### PR DESCRIPTION
it seems that they're specifically allergic against user agents that start with `Mozilla/` OR include the word `github` (that rules out the generic UA and the cobalt-specific UA in `config.js`), so I've just chosen to use `facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)`

(also, the `bilibili.com link with part id` test seems to be broken because the video it depends on seems to be gone?)