### PR TITLE
soundcloud: fix extraction of client_id

### DIFF
--- a/api/src/processing/services/soundcloud.js
+++ b/api/src/processing/services/soundcloud.js
@@ -15,24 +15,27 @@ async function findClientID() {
             return cachedID.id;
         }
 
-        const scripts = sc.matchAll(/<script.+src="(.+)">/g);
+        let clientid = sc.match(/"hydratable"\s*:\s*"apiClient"\s*,\s*"data"\s*:\s*\{\s*"id"\s*:\s*"([^"]+)"/)?.[1];
+        if (!clientid) {
+            const scripts = sc.matchAll(/<script.+src="(.+)">/g);
 
-        let clientid;
-        for (let script of scripts) {
-            const url = script[1];
+            for (let script of scripts) {
+                const url = script[1];
 
-            if (!url?.startsWith('https://a-v2.sndcdn.com/')) {
-                return;
-            }
+                if (!url?.startsWith('https://a-v2.sndcdn.com/')) {
+                    return;
+                }
 
-            const scrf = await fetch(url).then(r => r.text()).catch(() => {});
-            const id = scrf.match(/\("client_id=[A-Za-z0-9]{32}"\)/);
+                const scrf = await fetch(url).then(r => r.text()).catch(() => {});
+                const id = scrf.match(/,client_id:"([A-Za-z0-9]{32})",/);
 
-            if (id && typeof id[0] === 'string') {
-                clientid = id[0].match(/[A-Za-z0-9]{32}/)[0];
-                break;
+                if (id && id.length >= 2) {
+                    clientid = id[1];
+                    break;
+                }
             }
         }
+
         cachedID.version = scVersion;
         cachedID.id = clientid;
 


### PR DESCRIPTION
SoundCloud seems to have broken on main & develop because the regex for matching the client_id didn't match anything on newer versions anymore. This PR fixes the regex & tries to extract the client_id from hydration data first (before eventually falling back to getting it from the JS files)

The regex for matching the client_id from the hydration data is courtesy of https://git.canine.tools/canine.tools/cobalt/commit/6d77edd0a0fb5ac6b4083b40e66cf675281e2fed, thanks to @hyperdefined for it