### PR TITLE
Add 'pro' subdomain to tiktok service configuration

### DIFF
--- a/api/src/processing/service-config.js
+++ b/api/src/processing/service-config.js
@@ -152,7 +152,7 @@ export const services = {
             ":user/photo/:postId",
             "v/:postId.html"
         ],
-        subdomains: ["vt", "vm", "m", "t"],
+        subdomains: ["vt", "vm", "m", "t", "pro"],
     },
     tumblr: {
         patterns: [


### PR DESCRIPTION
TikTok Pro is nothing special, other than having some features stripped away to have a more comfortable doom scrolling experience. Sadly this also includes a "pro" subdomain, which cobalt doesn't detect.

Yes, you can manually strip away the pro part and get the same result, but for convenience and new users suddenly getting scared that TikTok downloads don't work anymore, the subdomain was added. 