### PR TITLE
web/download: fix false error popup on Firefox mobile

### DIFF
--- a/web/src/lib/download.ts
+++ b/web/src/lib/download.ts
@@ -56,15 +56,7 @@ export const openURL = (url: string) => {
         return alert('error: invalid url!');
     }
 
-    const open = window.open(url, "_blank", "noopener,noreferrer");
-
-    /* if new tab got blocked by user agent, show a saving dialog */
-    if (!open) {
-        return openSavingDialog({
-            url,
-            body: get(t)("dialog.saving.blocked")
-        });
-    }
+    window.open(url, "_blank", "noopener,noreferrer");
 }
 
 export const shareURL = async (url: string) => {


### PR DESCRIPTION
fixes #1523

window.open() return value is unreliable across browsers, especially on firefox mobile where it may return null even when the tab opens successfully.

this caused a false "blocked" download error to appear even when the download worked.

this change removes reliance on the return value of window.open() and prevents incorrect error dialogs.