### PR TITLE
api/instagram: prefer graphql over embed for posts

### DIFF
--- a/api/src/processing/services/instagram.js
+++ b/api/src/processing/services/instagram.js
@@ -305,6 +305,8 @@ export default function instagram(obj) {
         if (sidecar) {
             const picker = sidecar.edges.filter(e => e.node?.display_url)
                 .map((e, i) => {
+                    // if extracted from HTML embed, the first GraphVideo node from a "multipost" post sometimes
+                    // reports `is_video` without a `video_url`. this also breaks the official Instagram "multipost" embed.
                     const type = e.node?.is_video && e.node?.video_url ? "video" : "photo";
 
                     let url;
@@ -436,13 +438,13 @@ export default function instagram(obj) {
             if (media_id && !hasData(data)) data = await requestMobileApi(media_id);
             if (media_id && cookie && !hasData(data)) data = await requestMobileApi(media_id, { cookie });
 
-            // html embed (no cookie, cookie)
-            if (!hasData(data)) data = await requestHTML(id);
-            if (!hasData(data) && cookie) data = await requestHTML(id, cookie);
-
             // web app graphql api (no cookie, cookie)
             if (!hasData(data)) data = await requestGQL(id);
             if (!hasData(data) && cookie) data = await requestGQL(id, cookie);
+
+            // html embed (no cookie, cookie)
+            if (!hasData(data)) data = await requestHTML(id);
+            if (!hasData(data) && cookie) data = await requestHTML(id, cookie);
         } catch {}
 
         if (!hasData(data)) {


### PR DESCRIPTION
## what happened

When scraping the embed HTML for an Instagram post, carousel ("multipost") posts can expose media through a `contextJSON` payload. This property is empty for single-video posts, but appears for posts with multiple media items.

The problem is that, if a "multipost" has multiple videos, Instagram marks the first video node with `is_video`, but does not include a usable `video_url`.

The extractor then checks for both `is_video` and `video_url` before treating a node as downloadable video media:
https://github.com/imputnet/cobalt/blob/a636575b09de1fc55d9b8cd98cac88f5f2f16b42/api/src/processing/services/instagram.js#L308

Because the affected node is missing `video_url`, the extractor cannot expose it as a `video` and falls back to treating it as a `photo`.

This also appears to affect Instagram's official embed for the same "multipost" post. Example from the original issue:

https://github.com/user-attachments/assets/2fba35a7-2cbb-470a-87a4-dfd3f81e83d4


## what changed

This pull request changes the Instagram post fallback order so that the GraphQL API is tried before the embed HTML scrape.

GraphQL still returns data for single-video posts, and it also returns the correct `video_url` for the affected "multipost" posts. Keeping embed HTML as a later fallback preserves the existing recovery path without letting incomplete embed data win too early.

---

This fixes https://github.com/imputnet/cobalt/issues/1550
